### PR TITLE
Add markdown issues for plugin 1 scope

### DIFF
--- a/docs/issues/p1-01-alcance-checklist.md
+++ b/docs/issues/p1-01-alcance-checklist.md
@@ -1,0 +1,23 @@
+# P1: Alcance y checklist de entregables
+
+Referencia: docs/Plugin 1 — G3d Models Manager (ingesta Glb Y Binding Técnico) — Informe.md
+
+- [ ] Alcance confirmado (sin añadir nada fuera del doc).
+- [ ] Criterios de done copiados del doc.
+- [ ] Plan de pruebas copiado del doc.
+
+# 3) Alcance y límites
+#     • ✅ Ingesta de GLB uno a uno.
+#     • ✅ Extracción de props y anclas; detección de slots embebidos.
+#     • ✅ Generación de miniaturas/“golden shots”.
+#     • ✅ Validaciones técnicas (escala/ejes/props/anchos/altos).
+#     • ❌ No publica snapshots de catálogo (eso es del Catalog \& Rules).
+#     • ❌ No decide reglas editoriales (material↔modelo, etc.).
+
+# 4) Admin — Secciones
+#     • 4.5 Estado
+#         ◦ Borrador → Analizado → Aprobado técnico → Listo para Catálogo.
+
+# 15) QA \& Checklists
+#     • Pre-ready: anchors, props obligatorias, slots_detectados≠∅, golden shots, escala/ejes OK, peso OK.
+#     • Post-ready: endpoint GET /models/{id} devuelve todo; sincroniza con Catalog \& Rules sin warnings.

--- a/docs/issues/p1-02-esquema-identificadores.md
+++ b/docs/issues/p1-02-esquema-identificadores.md
@@ -1,0 +1,184 @@
+# P1: Esquema de identificadores (Capa 1)
+
+Referencia: docs/Capa 1 Identificadores Y Naming — Actualizada (slots Abiertos).md
+
+- [ ] Tabla de IDs/naming copiada (sin cambios).
+- [ ] Casos límite anotados del doc.
+
+Capa 1 — Identificadores y Naming (versión ACTUALIZADA — Slots abiertos)
+
+Objetivo
+
+Garantizar consistencia entre catálogo, visor, flujo de chips, carrito y analítica.
+
+IDs = claves estables para máquinas; Labels = textos vía i18n para humanos.
+
+Serialización canónica del estado para SKU.
+
+Reglas generales de IDs
+
+Slug interno regex: {3,48}$.
+
+ID completo entre plugins: ^(prod|pieza|modelo|mat|col|tex|fin|morph|sku):\[a-z0-9-]{3,48}$.
+
+Inmutables, únicos, opacos (sin medidas/fechas/idioma).
+
+Nunca se muestran al usuario.
+
+Prefijo opcionalmente omitido internamente si el campo ya lo implica.
+
+Prefijos de tipo
+
+prod: (producto), pieza:, modelo:, mat:, col:, tex:, fin:, morph:, sku:.
+
+Ej.: prod:rx-classic, pieza:moldura, modelo:fr-m1, mat:acetato, col:negro, tex:acetato-base, fin:clearcoat-high, morph:socket-w.
+
+Regla: no reutilizar mismo slug con distintos prefijos.
+
+IDs de publicación
+
+snap: = snapshot publicado, ver: = versión publicada.
+
+No sujetos al regex de IDs editoriales.
+
+Convenciones específicas
+
+Lado L/R en modelo (-l/-r), no en pieza.
+
+Variante R/U en campo variant del modelo.
+
+Familias: sufijos semánticos (-m1, -p2, etc.).
+
+Labels (i18n)
+
+label_key estable; traducciones en bundles por locale.
+
+Ejemplo clave: modelo.tp-p2-l.name.
+
+Plantilla resumen: {{pieza}} · {{material}} — {{color}} · {{textura}} · {{acabado}}.
+
+Fallbacks seguros: idioma actual → base → id capitalizado.
+
+Namespaces reservados: producto., pieza., modelo., material., color., textura., acabado.*.
+
+Campos mínimos por entidad
+
+Producto: id, label_key.
+
+Pieza: id, label_key.
+
+Modelo: id, pieza_id, label_key, variant (R/U), side (l/r/n).
+
+Material: id, label_key, defaults.
+
+Color: id, label_key, hex #RRGGBB uppercase.
+
+Textura: id, label_key, defines_color, slot: string libre (nombre embebido del GLB).
+
+Acabado: id, label_key.
+
+Morph: id, type (geometrico/correctivo), analytics_key opcional.
+
+Medidas
+
+socket_width_mm, socket_height_mm (moldura).
+
+lug_width_mm, lug_height_mm (patilla).
+
+tol_w_mm, tol_h_mm (tolerancias).
+
+Binding al GLB
+
+binding.source.file_name, object_name/object_name_pattern, model_code.
+
+props: medidas en mm.
+
+Resolución: preferencia por props, fallback por regex.
+
+Mantener ejes y escala coherentes (Z↑, mm).
+
+Slots dentro de una pieza
+
+• Un objeto GLB asociado a un modelo de una pieza puede traer uno o varios slots (superficies técnicas). • Si una pieza tiene >1 slot embebido, esa pieza tiene subzonas que se personalizan por separado desde Admin. • Los nombres de slot son técnicos (el dónde); la identidad visible la dan los controles definidos en Admin (el qué).
+
+Slots — definición ACTUALIZADA
+
+• Slots abiertos. El GLB puede traer cualquier slot embebido con cualquier nombre.
+
+• Los slots son identificadores técnicos del GLB; su uso real depende del Admin/editorial.
+
+• En Admin se definen controles por slot (material/color/textura/acabado/shader_params) y sus defaults. El slot es el dónde; los controles definen el qué. Opcionalmente, cada control puede marcarse affects_sku:true|false según afecte al SKU.
+
+Morphs (naming)
+
+Tipos: geometrico (POSITION), correctivo (NORMAL/TANGENT).
+
+IDs sugeridos: morph:socket-w, morph:socket-h, morph:corner-radius.
+
+Rango y clearances en capas superiores.
+
+Serialización del Estado/SKU
+
+Bloques por pieza, claves pieza→mat→modelo→col→tex→fin.
+
+Orden de piezas editorial fijo.
+
+Morphs no viajan en SKU (derivables de snapshot+encaje).
+
+Modo avanzado: incluir morphs normalizados.
+
+Versionado
+
+schema_version en payloads (SemVer).
+
+Cambios incompatibles ⇒ major.
+
+Palabras reservadas
+
+No usar: default, all, none, true, false, null, na, r, u, l.
+
+Deprecación
+
+deprecated: true, superseded_by: .
+
+Mantener mientras existan SKUs vigentes.
+
+Buenas prácticas
+
+IDs cortos, claros, consistentes.
+
+No duplicar significado entre ID y label.
+
+No incluir medidas/temporada en IDs.
+
+Migración términos
+
+part → pieza, form → modelo.
+
+QA: scripts bloquean alias legacy.
+
+Checklist rápida
+
+IDs cumplen regex.
+
+Lado solo en modelo.
+
+Labels solo con label_key.
+
+HEX válido.
+
+Medidas en *_mm.
+
+Binding completo.
+
+SKU serializado correctamente.
+
+schema_version presente.
+
+Palabras reservadas no usadas.
+
+No sustituir assets publicados.
+
+Namespaces i18n correctos.
+
+Apéndices - Reglas de linting (IDs, hex, label_key, unicidad). - Ejemplo de binding robusto con props y regex.

--- a/docs/issues/p1-03-ingesta-glb-validaciones.md
+++ b/docs/issues/p1-03-ingesta-glb-validaciones.md
@@ -1,0 +1,36 @@
+# P1: Ingesta GLB y validaciones mínimas
+
+Referencia: docs/Plugin 1 — G3d Models Manager (ingesta Glb Y Binding Técnico) — Informe.md
+
+- [ ] Flujo de subida conforme al doc.
+- [ ] Validaciones de tamaño/formatos del doc.
+- [ ] Manejo de errores tal como el doc.
+
+# 4) Admin — Secciones
+#     • 4.1 Ingesta GLB
+#         ◦ Subir archivo (drag&drop + checksum).
+#         ◦ Metadatos: tamaño, hash, compresión (Draco), bounding boxes.
+#     • 4.2 Análisis & Binding
+#         ◦ Slots detectados (lista de nombres tal cual vienen del GLB).
+#         ◦ Anchors obligatorios: Frame_Anchor, Temple_L_Anchor, Temple_R_Anchor, Socket_Cage (si aplica).
+#         ◦ Props leídas del objeto: socket_*_mm, lug_*_mm, side, variant, mount_type, tolerancias.
+#         ◦ Object name / pattern y model_code.
+#     • 4.3 Previsualización
+#         ◦ Viewer simple con cámara fija + wireframe toggle.
+#         ◦ Golden shots (auto/forzar regeneración).
+#     • 4.4 Validaciones
+#         ◦ Escala (mm → escena), ejes Z↑, pivotes correctos.
+#         ◦ Props obligatorias según pieza.
+#         ◦ Presencia de anchors.
+#         ◦ Tamaño máximo GLB.
+
+# 8) Flujos críticos
+#     • Ingesta → Análisis → Aprobación técnica → Ready → Sync a Catálogo.
+#     • Rechazo con motivos y acciones sugeridas (arreglar pivote, añadir prop, re-exportar con Draco).
+
+# 9) Errores \& Zero-mensajes
+#     • Errores estándar: E_ASSET_MISSING, E_PROP_MISSING, E_ANCHOR_MISSING, E_SCALE_INVALID, E_AXES_INVALID, E_FILE_TOO_LARGE, E_SLOTS_EMPTY.
+#     • En front público no aparecen; solo métricas/logs. El configurador nunca depende directamente del Admin de este plugin.
+
+# 10) Rendimiento
+#     • GLB por pieza ≤ 2–3 MB (objetivo); hard cap configurable (p. ej., 12 MB).

--- a/docs/issues/p1-04-binding-tecnico.md
+++ b/docs/issues/p1-04-binding-tecnico.md
@@ -1,0 +1,186 @@
+# P1: Binding técnico a slots/Capa T
+
+Referencia: docs/Capa T — 3d Assets & Export — Actualizada V2 (revisada Con Controles Por Slot).md
+
+- [ ] Reglas de slot aplicadas tal cual están.
+- [ ] Metadatos requeridos copiados.
+
+Capa T — 3D Assets & Export (ACTUALIZADA — Slots abiertos)
+
+🧭 Reglas rápidas
+
+Encaje = Y + W (mm) de la raíz/“socket”.
+
+Y = altura de la raíz (vertical).
+
+W = ancho de la raíz (horizontal en vista Front).
+
+Los nombres llevan Y-W redondeados al mm para leer rápido. Las propiedades guardan los mm exactos.
+
+FRAMED = con montura (socket). RIMLESS = sin montura (atornillada al lente).
+
+Monturas FRAMED tienen dos variantes: _R realista (socket modelado) · _U universal (borde plano).
+
+Los materiales y slots del GLB son abiertos: nómbralos de forma estable (p. ej., MAT_*). No existe una lista fija.
+
+🔣 Códigos
+
+FR = Frame (montura)
+
+TP = Temple (patilla)
+
+RM = Rimless Mount (pieza de sujeción en rimless)
+
+Lado: L izquierda · R derecha
+
+Variante montura: R realista · U universal
+
+Modelo: letra/código libre (A, B, C…)
+
+Unidades: milímetros (mm)
+
+🧾 Propiedades (Custom Properties) — en el OBJETO
+
+(Objeto → Object Properties → Custom Properties → Add)
+
+Comunes
+
+model_code → “A” (tu código de modelo)
+
+Patillas FRAMED
+
+lug_height_mm → Y exacto (ej. 11.7)
+
+lug_width_mm → W exacto (ej. 6.25)
+
+side → “L” / “R”
+
+(opcional) tol_h_mm = 0.7 · tol_w_mm = 0.4
+
+Monturas FRAMED
+
+mount_type → “FRAMED”
+
+variant → “R” o “U”
+
+(solo realista)
+
+socket_height_mm → Y exacto
+
+socket_width_mm → W exacto
+
+(opcional) tol_h_mm = 0.7 · tol_w_mm = 0.4
+
+Rimless (RM)
+
+mount_type → “RIMLESS”
+
+(opcional futuro) rimless_family, hole_spacing_mm, hole_diameter_mm
+
+Patillas Rimless
+
+fit → “R”
+
+side → “L” / “R”
+
+(opcional) rimless_family
+
+Materiales y slots (nota editorial)
+
+• Los slots son abiertos. El GLB puede traer cualquier slot embebido con cualquier nombre (p. ej., MAT_BASE, MAT_TIP, MAT_LENS, MAT_XYZ…).
+
+• Los slots son identificadores técnicos del GLB; su uso real depende del Admin/editorial.
+
+• En Admin se definen controles por slot (material/color/textura/acabado/shader_params) con defaults y, opcionalmente, affects_sku:true|false por control. El slot es el dónde; los controles definen el qué.
+
+🧱 Plantillas para rellenar
+
+Montura FRAMED realista
+
+[OBJETO]
+
+Nombre: FR{Modelo}_{Yredondeado}-{Wredondeado}_R
+
+model_code: “{Modelo}”
+
+mount_type: “FRAMED”
+
+variant: “R”
+
+socket_height_mm: {Y exacto}
+
+socket_width_mm: {W exacto}
+
+tol_h_mm: 0.7
+
+tol_w_mm: 0.4
+
+Montura FRAMED universal
+
+[OBJETO]
+
+Nombre: FR{Modelo}_U
+
+model_code: “{Modelo}”
+
+mount_type: “FRAMED”
+
+variant: “U”
+
+Patilla FRAMED (izq./dcha.)
+
+[OBJETO]
+
+Nombre: TP{Modelo}{Yredondeado}-{Wredondeado}{L|R}
+
+model_code: “{Modelo}”
+
+lug_height_mm: {Y exacto}
+
+lug_width_mm: {W exacto}
+
+side: “{L|R}”
+
+tol_h_mm: 0.7
+
+tol_w_mm: 0.4
+
+Rimless – pieza de sujeción (lugs/bridge)
+
+[OBJETO]
+
+Nombre: RM{Modelo}
+
+model_code: “{Modelo}”
+
+mount_type: “RIMLESS”
+
+Patilla Rimless (izq./dcha.)
+
+[OBJETO]
+
+Nombre: TP{Modelo}R{L|R}
+
+model_code: “{Modelo}”
+
+fit: “R”
+
+side: “{L|R}”
+
+✅ Checklist de exportación
+
+Escala normalizada (montura X ≈ 0.145 m), Ctrl+A → All Transforms.
+
+Pivotes:
+
+Montura → puente (idealmente 0,0,0).
+
+Patillas → centro del eje de su bisagra.
+
+Nombres según convención Y–W.
+
+Custom Properties añadidas (Y/W exactos y tolerancias).
+
+Slots abiertos en materiales: usa nombres estables (MAT_*), evita dependencias de listas fijas.
+
+En glTF: incluir custom properties activado.

--- a/docs/issues/p1-05-interfaz-admin.md
+++ b/docs/issues/p1-05-interfaz-admin.md
@@ -1,0 +1,56 @@
+# P1: Interfaz mínima de administración
+
+Referencia: docs/Plugin 1 — ... Informe.md y Capa 4 — Ui_ux Orquestación — Addenda ....md
+
+- [ ] Pantallas/acciones listadas exactamente como en el doc.
+- [ ] Textos/etiquetas tomadas del doc (i18n si procede).
+
+# 4) Admin — Secciones
+#     • 4.1 Ingesta GLB
+#         ◦ Subir archivo (drag&drop + checksum).
+#         ◦ Metadatos: tamaño, hash, compresión (Draco), bounding boxes.
+#     • 4.2 Análisis & Binding
+#         ◦ Slots detectados (lista de nombres tal cual vienen del GLB).
+#         ◦ Anchors obligatorios: Frame_Anchor, Temple_L_Anchor, Temple_R_Anchor, Socket_Cage (si aplica).
+#         ◦ Props leídas del objeto: socket_*_mm, lug_*_mm, side, variant, mount_type, tolerancias.
+#         ◦ Object name / pattern y model_code.
+#     • 4.3 Previsualización
+#         ◦ Viewer simple con cámara fija + wireframe toggle.
+#         ◦ Golden shots (auto/forzar regeneración).
+#     • 4.4 Validaciones
+#         ◦ Escala (mm → escena), ejes Z↑, pivotes correctos.
+#         ◦ Props obligatorias según pieza.
+#         ◦ Presencia de anchors.
+#         ◦ Tamaño máximo GLB.
+#     • 4.5 Estado
+#         ◦ Borrador → Analizado → Aprobado técnico → Listo para Catálogo.
+#     • 4.6 Historial
+#         ◦ Versiones del mismo modelo (hashes, diffs técnicos).
+#     • 4.7 Export/Sync
+#         ◦ Solo de datos técnicos hacia Catalog \& Rules.
+
+Capa 4 — UI/UX, Orquestación, Accesibilidad y Métricas (ACTUALIZADA — Slots abiertos)
+
+Principios de diseño
+
+Zero-mensajes: sin banners ni errores visibles; autocorrección silenciosa.
+
+Determinismo: misma entrada ⇒ mismo estado/sku_hash.
+
+Velocidad: TTI/LCP < 2.5 s; primer frame < 200 ms.
+
+Accesibilidad WCAG 2.2 AA.
+
+Consistencia: Resumen ≡ chips ≡ visor.
+
+Serialización estable: orden fijo pieza→mat→modelo→col→tex→fin.
+
+Slots abiertos (definidos por el GLB): en Admin se definen controles por slot (material/color/textura/acabado/shader_params) con defaults y, opcionalmente, affects_sku:true|false por control. El slot es el dónde; los controles el qué.
+
+Estructura de pantalla Desktop ≥1024px: visor 3D izquierda, chips derecha. Mobile <1024px: visor arriba, pasos en acordeón. Header: título, precio opcional, compartir. Footer fijo: CTA carrito + resumen. Orden de pasos: Pieza → Material → Modelo → Color → Textura → Acabado.
+
+Componentes de UI 2.1 Stepper (tabs ARIA correctos, teclado completo). 2.2 Chips: radiogroup, accesibles, hit-area ≥44 px, overflow con carrusel y modal. 2.2.1 Chips por slot (si la pieza tiene >1 slot): agrupar por slot (título corto); cada grupo como radiogroup independiente con undo/redo y ARIA correcta. 2.3 Visor 3D: gestos, teclado, toolbar mínima, cámara determinista, fallback estático. 2.4 Resumen: plantilla i18n, live region aria-live. 2.5 CTA Carrito: siempre habilitada, valida en silencio. 2.6 Screenshot: JPG 1024×1024, cache por sku_hash.
+
+i18n Labels por label_key, bundles por idioma, fallback seguro. Intl para números/fechas.
+
+Checklists Front: stepper/chips ARIA, computeAllowed, autocorrección, undo/redo, telemetría, Intl. Visor: gestos, cross-fade, fallback, prefetch. Contenido/i18n: labels correctos, sin IDs crudos.

--- a/docs/issues/p1-06-pruebas-ci.md
+++ b/docs/issues/p1-06-pruebas-ci.md
@@ -1,0 +1,14 @@
+# P1: Pruebas y CI
+
+Referencia: docs/Plano De Plugins — Propuesta V1 (basado En Capas 1–5 Y T).md
+
+- [ ] Pruebas alineadas con verify.* del repo (sin ampliar alcance).
+- [ ] Empaquetado ZIP por plugin según doc.
+
+Plano de Plugins — Propuesta v2 (Enterprise)
+
+Decisión tomada: mantener 6 plugins (4 core + 2 helpers) con overlay solo visual en el tema hijo. Arquitectura alineada con Capas 1–5 y T; slots abiertos; Zero‑mensajes; snapshot inmutable; firma Ed25519.
+
+## 6) Telemetría y A/B - Eventos: ui.ready/select/autocorrect/add_to_cart/error/snapshot_ready. - Dimensiones: producto_id, pieza_id, material_id, modelo_id, color_id, textura_id, acabado_id, variante_ab, device, locale, texture_source, tint_applied, slot_name y, por control, control_type/control_value_id. - KPI: tiempo a config, % autocorrecciones, éxito add‑to‑cart, latencias validate/verify. - A/B: orden Color↔Textura, carrusel vs grid, “Acabado por lado” (parejas L/R).
+
+## 7) Packaging & versionado - Zips: slug-vMAJOR.MINOR.PATCH.zip con README, CHANGELOG, MANIFEST, scripts/verify.*. - Compatibilidad: N / N‑1 para APIs y firma (sig.vN). - CDN: invalidación controlada tras publicar snapshot; cache por sku_hash+snapshot_id.

--- a/docs/issues/p1-07-documentacion.md
+++ b/docs/issues/p1-07-documentacion.md
@@ -1,0 +1,76 @@
+# P1: Documentación
+
+Referencia: docs/Plugin 1 — ... Informe.md
+
+- [ ] README del plugin (copiar secciones del doc).
+- [ ] Ejemplos/limitaciones exactamente como el doc.
+
+# 1) Identidad
+#     • Objetivo: recibir GLB por pieza, analizarlos y fijar el binding técnico (props, anclas, slots detectados) que usarán los demás plugins.
+
+# 2) Visibilidad
+#     • Front (público): no visible. Su “resultado” es datos confiables (URLs GLB, props mm, slots_detectados) para el visor.
+#     • Admin: sí. Panel de ingesta y análisis de modelos.
+
+# 3) Alcance y límites
+#     • ✅ Ingesta de GLB uno a uno.
+#     • ✅ Extracción de props y anclas; detección de slots embebidos.
+#     • ✅ Generación de miniaturas/“golden shots”.
+#     • ✅ Validaciones técnicas (escala/ejes/props/anchos/altos).
+#     • ❌ No publica snapshots de catálogo (eso es del Catalog \& Rules).
+#     • ❌ No decide reglas editoriales (material↔modelo, etc.).
+
+# 5) Modelo de datos (resumen)
+#     • Model (CPT g3d_model):
+#         ◦ id (UUID), piece_type (FRAME|TEMPLE|RIMLESS)
+#         ◦ file_url, file_hash, filesize_bytes, draco_enabled
+#         ◦ object_name, object_name_pattern, model_code
+#         ◦ Props (según pieza):
+#             ▪ FRAME (FRAMED): socket_width_mm, socket_height_mm, variant, mount_type
+# 
+#             ▪ TEMPLE: lug_width_mm, lug_height_mm, side
+# 
+#             ▪ RIMLESS: mount_type, (extensibles: hole_spacing_mm, etc.)
+#         ◦ tolerances: tol_w_mm, tol_h_mm (opcionales)
+#         ◦ anchors_present[]
+#         ◦ slots_detectados[] (strings sin normalizar; slots abiertos)
+#         ◦ analysis_report (JSON), golden_shots[]
+#         ◦ status: draft|analyzed|approved|ready
+#         ◦ created_by, updated_by, created_at, updated_at
+
+# 6) APIs/Contratos (ejemplos)
+#     • POST /models → subir GLB (devuelve id, file_hash).
+#     • POST /models/{id}/analyze → corre análisis, llena slots_detectados, anchors_present, props.
+#     • GET /models/{id} → ficha técnica.
+#     • GET /models?status=ready&piece_type=FRAME → listas filtradas.
+#     • Evento model.analyzed (payload con id, slots_detectados, props).
+
+# 7) RBAC
+#     • Editor Técnico: subir GLB, lanzar análisis, editar metadata.
+#     • QA Técnico: validar/aprobar técnico.
+#     • Admin: borrar, restaurar, configurar límites (peso, props requeridas).
+#     • Solo lectura: ver fichas/descargas.
+
+# 8) Flujos críticos
+#     • Ingesta → Análisis → Aprobación técnica → Ready → Sync a Catálogo.
+#     • Rechazo con motivos y acciones sugeridas (arreglar pivote, añadir prop, re-exportar con Draco).
+
+# 9) Errores \& Zero-mensajes
+#     • Errores estándar: E_ASSET_MISSING, E_PROP_MISSING, E_ANCHOR_MISSING, E_SCALE_INVALID, E_AXES_INVALID, E_FILE_TOO_LARGE, E_SLOTS_EMPTY.
+#     • En front público no aparecen; solo métricas/logs. El configurador nunca depende directamente del Admin de este plugin.
+
+# 11) Observabilidad
+#     • Logs JSON con request_id, model_id, file_hash.
+#     • Métricas: % con anchors válidos, % con props completas, media de slots/pieza, peso medio GLB, tasa de rechazo.
+
+# 12) Seguridad
+#     • Subida autenticada, verificación de tipo/virus.
+#     • Rutas privadas para originales; públicos solo los GLB “ready” en CDN.
+
+# 13) Versionado \& Packaging
+#     • g3d-models-manager-vX.Y.Z.zip con README/CHANGELOG/MANIFEST y scripts verify.* (validación post-instalación).
+#     • Compatibilidad de API con N/N-1.
+
+# 14) Backups \& DR
+#     • Metadatos en DB, GLB en storage (S3/CDN).
+#     • RPO ≤ 24h, RTO ≤ 4h; pruebas trimestrales.


### PR DESCRIPTION
## Summary
- add P1 issue descriptions under docs/issues/ with text copied directly from the referenced design docs
- capture scope, identifiers, ingest validations, binding rules, admin UI, CI guidance, and documentation requirements for plugin 1

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d9be42799883238583bb7465c7ae4d