### PR TITLE
Add PHPUnit coverage for GLB ingestion rules

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,27 @@
+name: PHPUnit
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Install dependencies
+        working-directory: plugins/g3d-models-manager
+        run: composer install --no-interaction --no-progress
+
+      - name: Run PHPUnit
+        working-directory: plugins/g3d-models-manager
+        run: vendor/bin/phpunit

--- a/plugins/g3d-models-manager/composer.json
+++ b/plugins/g3d-models-manager/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "g3d/models-manager",
+    "description": "Development dependencies for the G3D Models Manager plugin tests.",
+    "type": "project",
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "G3D\\ModelsManager\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "G3D\\ModelsManager\\Tests\\": "tests/"
+        }
+    },
+    "minimum-stability": "stable",
+    "license": "proprietary"
+}

--- a/plugins/g3d-models-manager/phpunit.xml.dist
+++ b/plugins/g3d-models-manager/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="G3D Models Manager Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/plugins/g3d-models-manager/tests/GlbIngestionValidatorTest.php
+++ b/plugins/g3d-models-manager/tests/GlbIngestionValidatorTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\ModelsManager\Tests;
+
+use G3D\ModelsManager\Validation\GlbIngestionValidator;
+use PHPUnit\Framework\TestCase;
+
+final class GlbIngestionValidatorTest extends TestCase
+{
+    public function testRejectsWhenMissingRequiredAssetMetadata(): void
+    {
+        $validator = new GlbIngestionValidator();
+
+        $errors = $validator->validate([]);
+
+        $this->assertContains('E_ASSET_MISSING', $this->extractCodes($errors));
+    }
+
+    public function testRejectsWhenScaleNotInMillimeters(): void
+    {
+        $validator = new GlbIngestionValidator();
+
+        $metadata = $this->createValidFrameMetadata();
+        $metadata['scale_unit'] = 'meters';
+
+        $errors = $validator->validate($metadata);
+
+        $this->assertContains('E_SCALE_INVALID', $this->extractCodes($errors));
+    }
+
+    public function testRejectsWhenFramePropsMissing(): void
+    {
+        $validator = new GlbIngestionValidator();
+
+        $metadata = $this->createValidFrameMetadata();
+        unset($metadata['props']['socket_height_mm']);
+
+        $errors = $validator->validate($metadata);
+
+        $this->assertContains('E_PROP_MISSING', $this->extractCodes($errors));
+    }
+
+    public function testRejectsWhenSocketCageAnchorMissing(): void
+    {
+        $validator = new GlbIngestionValidator();
+
+        $metadata = $this->createValidFrameMetadata();
+        $metadata['anchors_present'] = [
+            'Frame_Anchor',
+            'Temple_L_Anchor',
+            'Temple_R_Anchor',
+        ];
+
+        $errors = $validator->validate($metadata);
+
+        $this->assertContains('E_ANCHOR_MISSING', $this->extractCodes($errors));
+    }
+
+    public function testRejectsWhenSlotsListEmpty(): void
+    {
+        $validator = new GlbIngestionValidator();
+
+        $metadata = $this->createValidFrameMetadata();
+        $metadata['slots_detectados'] = ['   '];
+
+        $errors = $validator->validate($metadata);
+
+        $this->assertContains('E_SLOTS_EMPTY', $this->extractCodes($errors));
+    }
+
+    public function testAcceptsValidFrameGlbMetadata(): void
+    {
+        $validator = new GlbIngestionValidator();
+
+        $errors = $validator->validate($this->createValidFrameMetadata());
+
+        $this->assertSame([], $errors);
+    }
+
+    /**
+     * @param array<int, \G3D\ModelsManager\Validation\GlbValidationError> $errors
+     * @return array<int, string>
+     */
+    private function extractCodes(array $errors): array
+    {
+        return array_map(static function ($error): string {
+            return $error->getCode();
+        }, $errors);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function createValidFrameMetadata(): array
+    {
+        return [
+            'file_hash' => 'abc123',
+            'filesize_bytes' => 1024,
+            'scale_unit' => 'mm',
+            'up_axis' => 'Z',
+            'pivot_at_origin' => true,
+            'piece_type' => GlbIngestionValidator::PIECE_TYPE_FRAME,
+            'props' => [
+                'socket_width_mm' => 12.5,
+                'socket_height_mm' => 6.2,
+                'variant' => 'R',
+                'mount_type' => 'FRAMED',
+            ],
+            'anchors_present' => [
+                'Frame_Anchor',
+                'Temple_L_Anchor',
+                'Temple_R_Anchor',
+                'Socket_Cage',
+            ],
+            'slots_detectados' => ['MAT_BASE'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit configuration and composer metadata for the G3D Models Manager plugin
- cover GLB ingestion validator behaviours required by the ingestion and slot documentation
- wire a GitHub Actions workflow to run the plugin's PHPUnit suite on PHP 8.2

## Testing
- `composer install --no-interaction --no-progress` (from `plugins/g3d-models-manager`)
- `vendor/bin/phpunit` (from `plugins/g3d-models-manager`)


------
https://chatgpt.com/codex/tasks/task_e_68d9e5e9a7ac8323939ac31e90dfde0c