### PR TITLE
feat: stub REST contracts for Validate & Sign plugin

### DIFF
--- a/plugins/g3d-validate-sign/README.md
+++ b/plugins/g3d-validate-sign/README.md
@@ -1,2 +1,7 @@
-# Esqueleto del plugin
-Este directorio corresponde al plugin. Aún sin código: se añadirá en fases.
+# G3D Validate & Sign
+
+Este plugin sigue las especificaciones descritas en:
+
+- [docs/plugin-3-g3d-validate-sign.md](../../docs/plugin-3-g3d-validate-sign.md)
+- [docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md](../../docs/Capa%203%20%E2%80%94%20Validaci%C3%B3n%2C%20Firma%20Y%20Caducidad%20%E2%80%94%20Actualizada%20(slots%20Abiertos)%20%E2%80%94%20V2%20(urls).md)
+- [docs/Capa 1 Identificadores Y Naming — Actualizada (slots Abiertos).md](../../docs/Capa%201%20Identificadores%20Y%20Naming%20%E2%80%94%20Actualizada%20(slots%20Abiertos).md)

--- a/plugins/g3d-validate-sign/plugin.php
+++ b/plugins/g3d-validate-sign/plugin.php
@@ -25,3 +25,22 @@ register_deactivation_hook(__FILE__, function () {
 add_action('init', function () {
     load_plugin_textdomain('g3d-validate-sign', false, dirname(plugin_basename(__FILE__)) . '/languages');
 });
+
+add_action('rest_api_init', function () {
+    $basePath = plugin_dir_path(__FILE__);
+
+    require_once $basePath . 'src/Validation/RequestValidator.php';
+    require_once $basePath . 'src/Api/ValidateSignController.php';
+    require_once $basePath . 'src/Api/VerifyController.php';
+
+    $validateRequestValidator = new \G3D\ValidateSign\Validation\RequestValidator(
+        $basePath . 'schemas/validate-sign.request.schema.json'
+    );
+
+    $verifyRequestValidator = new \G3D\ValidateSign\Validation\RequestValidator(
+        $basePath . 'schemas/verify.request.schema.json'
+    );
+
+    (new \G3D\ValidateSign\Api\ValidateSignController($validateRequestValidator))->registerRoutes();
+    (new \G3D\ValidateSign\Api\VerifyController($verifyRequestValidator))->registerRoutes();
+});

--- a/plugins/g3d-validate-sign/schemas/validate-sign.request.schema.json
+++ b/plugins/g3d-validate-sign/schemas/validate-sign.request.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://blind.local/plugins/g3d-validate-sign/schemas/validate-sign.request.schema.json",
+  "title": "POST /validate-sign request",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "snapshot_id",
+    "producto_id",
+    "state",
+    "locale"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "$comment": "SemVer requerido. TODO: Definir validación exacta según docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md (Compatibilidad y versionado)."
+    },
+    "snapshot_id": {
+      "type": "string",
+      "$comment": "ID de snapshot publicado. Ver docs/plugin-3-g3d-validate-sign.md §6.1 y docs/Capa 1 Identificadores Y Naming — Actualizada (slots Abiertos).md."
+    },
+    "producto_id": {
+      "type": "string",
+      "$comment": "ID estable de producto según docs/Capa 1 Identificadores Y Naming — Actualizada (slots Abiertos).md."
+    },
+    "state": {
+      "type": "object",
+      "$comment": "Estado serializado pieza→mat→modelo→col→tex→fin según docs/plugin-3-g3d-validate-sign.md §6.1. TODO: Detallar estructura exacta."
+    },
+    "locale": {
+      "type": "string",
+      "$comment": "Locale de la petición. TODO: Definir lista permitida según docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md."
+    },
+    "flags": {
+      "$comment": "Campo opcional (flags?) indicado en docs/plugin-3-g3d-validate-sign.md §6.1. TODO: Definir estructura."
+    }
+  },
+  "additionalProperties": true
+}

--- a/plugins/g3d-validate-sign/schemas/validate-sign.response.schema.json
+++ b/plugins/g3d-validate-sign/schemas/validate-sign.response.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://blind.local/plugins/g3d-validate-sign/schemas/validate-sign.response.schema.json",
+  "title": "POST /validate-sign response",
+  "type": "object",
+  "required": [
+    "ok",
+    "sku_hash",
+    "sku_signature",
+    "expires_at",
+    "snapshot_id",
+    "summary",
+    "request_id"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "$comment": "Debe ser true en caso de éxito según docs/plugin-3-g3d-validate-sign.md §6.1."
+    },
+    "sku_hash": {
+      "type": "string",
+      "$comment": "SHA-256 del estado canónico (ver docs/plugin-3-g3d-validate-sign.md §6.1)."
+    },
+    "sku_signature": {
+      "type": "string",
+      "$comment": "Firma sig.vN Ed25519 (ver docs/plugin-3-g3d-validate-sign.md §6.1)."
+    },
+    "expires_at": {
+      "type": "string",
+      "$comment": "Fecha en ISO8601 con TTL configurado (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md, sección SKU, firma y caducidad)."
+    },
+    "snapshot_id": {
+      "type": "string",
+      "$comment": "ID del snapshot usado en la validación (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md)."
+    },
+    "summary": {
+      "type": "string",
+      "$comment": "Resumen textual siguiendo naming de docs/Capa 1 Identificadores Y Naming — Actualizada (slots Abiertos).md."
+    },
+    "price": {
+      "$comment": "Campo opcional price? (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md, API 2.1). TODO: Definir tipo."
+    },
+    "stock": {
+      "$comment": "Campo opcional stock? (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md, API 2.1). TODO: Definir tipo."
+    },
+    "photo_url": {
+      "$comment": "Campo opcional photo_url? TTL 90 días (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md, sección SKU, firma y caducidad). TODO: Definir tipo."
+    },
+    "request_id": {
+      "type": "string",
+      "$comment": "Identificador para auditoría y observabilidad (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md)."
+    }
+  },
+  "additionalProperties": true
+}

--- a/plugins/g3d-validate-sign/schemas/verify.request.schema.json
+++ b/plugins/g3d-validate-sign/schemas/verify.request.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://blind.local/plugins/g3d-validate-sign/schemas/verify.request.schema.json",
+  "title": "POST /verify request",
+  "type": "object",
+  "required": [
+    "sku_hash",
+    "sku_signature",
+    "snapshot_id"
+  ],
+  "properties": {
+    "sku_hash": {
+      "type": "string",
+      "$comment": "Hash determinista de SKU según docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md, sección SKU, firma y caducidad."
+    },
+    "sku_signature": {
+      "type": "string",
+      "$comment": "Firma Ed25519 sig.vN según docs/plugin-3-g3d-validate-sign.md §6.2."
+    },
+    "snapshot_id": {
+      "type": "string",
+      "$comment": "Snapshot a verificar (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md)."
+    }
+  },
+  "additionalProperties": true
+}

--- a/plugins/g3d-validate-sign/schemas/verify.response.schema.json
+++ b/plugins/g3d-validate-sign/schemas/verify.response.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://blind.local/plugins/g3d-validate-sign/schemas/verify.response.schema.json",
+  "title": "POST /verify response",
+  "type": "object",
+  "required": [
+    "ok",
+    "request_id"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "$comment": "ok:true indica verificación correcta; ok:false mapeará códigos de error según docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md, sección 2.2."
+    },
+    "code": {
+      "type": "string",
+      "$comment": "Errores como E_SIGN_EXPIRED, E_SIGN_INVALID, etc. (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md)."
+    },
+    "reason_key": {
+      "type": "string",
+      "$comment": "reason_key snake_case para analítica (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md)."
+    },
+    "detail": {
+      "type": "string",
+      "$comment": "Descripción opcional. TODO: Definir formato exacto según docs/plugin-3-g3d-validate-sign.md §6.2."
+    },
+    "request_id": {
+      "type": "string",
+      "$comment": "Identificador de auditoría (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md, Observabilidad)."
+    }
+  },
+  "additionalProperties": true
+}

--- a/plugins/g3d-validate-sign/src/Api/ValidateSignController.php
+++ b/plugins/g3d-validate-sign/src/Api/ValidateSignController.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\ValidateSign\Api;
+
+use G3D\ValidateSign\Validation\RequestValidator;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+class ValidateSignController
+{
+    private RequestValidator $validator;
+
+    public function __construct(RequestValidator $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    public function registerRoutes(): void
+    {
+        register_rest_route(
+            'g3d/v1',
+            '/validate-sign',
+            [
+                'methods' => 'POST',
+                'callback' => [$this, 'handle'],
+                'permission_callback' => '__return_true', // TODO: Permisos (ver plugin-3-g3d-validate-sign.md §7).
+            ]
+        );
+    }
+
+    public function handle(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        $payload = $request->get_json_params();
+
+        if (!is_array($payload)) {
+            $payload = [];
+        }
+
+        $validation = $this->validator->validate($payload);
+
+        if (!empty($validation['missing'])) {
+            return new WP_Error(
+                'rest_missing_required_params',
+                'Faltan campos requeridos.',
+                [
+                    'status' => 400,
+                    'missing_fields' => $validation['missing'],
+                ]
+            );
+        }
+
+        if (!empty($validation['type'])) {
+            return new WP_Error(
+                'rest_invalid_param',
+                'Tipos inválidos detectados.',
+                [
+                    'status' => 400,
+                    'type_errors' => $validation['type'],
+                ]
+            );
+        }
+
+        $response = [
+            'ok' => true,
+            'sku_hash' => 'TODO: SHA-256 canónico (ver plugin-3-g3d-validate-sign.md §6.1).',
+            'sku_signature' => 'TODO: Firma sig.vN Ed25519 (ver plugin-3-g3d-validate-sign.md §6.1).',
+            'expires_at' => 'TODO: ISO8601 + TTL (ver Capa 3 — Validación, Firma Y Caducidad — V2, API 2.1).',
+            'snapshot_id' => $payload['snapshot_id']
+                ?? 'TODO: snapshot_id eco (ver Capa 3 — Validación, Firma Y Caducidad — V2).',
+            'summary' => 'TODO: Plantilla resumen (ver Capa 1 Identificadores Y Naming).',
+            'price' => null, // TODO: Precio opcional (ver Capa 3 — Validación, Firma Y Caducidad — V2).
+            'stock' => null, // TODO: Stock opcional (ver Capa 3 — Validación, Firma Y Caducidad — V2).
+            'photo_url' => null, // TODO: URL TTL 90 días (ver Capa 3 — Validación, Firma Y Caducidad — V2).
+            'request_id' => 'TODO: request_id (ver Capa 3 — Validación, Firma Y Caducidad — V2, Observabilidad).',
+        ];
+
+        return new WP_REST_Response($response, 200);
+    }
+}

--- a/plugins/g3d-validate-sign/src/Api/VerifyController.php
+++ b/plugins/g3d-validate-sign/src/Api/VerifyController.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\ValidateSign\Api;
+
+use G3D\ValidateSign\Validation\RequestValidator;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+class VerifyController
+{
+    private RequestValidator $validator;
+
+    public function __construct(RequestValidator $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    public function registerRoutes(): void
+    {
+        register_rest_route(
+            'g3d/v1',
+            '/verify',
+            [
+                'methods' => 'POST',
+                'callback' => [$this, 'handle'],
+                'permission_callback' => '__return_true', // TODO: Permisos (ver plugin-3-g3d-validate-sign.md §7).
+            ]
+        );
+    }
+
+    public function handle(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        $payload = $request->get_json_params();
+
+        if (!is_array($payload)) {
+            $payload = [];
+        }
+
+        $validation = $this->validator->validate($payload);
+
+        if (!empty($validation['missing'])) {
+            return new WP_Error(
+                'rest_missing_required_params',
+                'Faltan campos requeridos.',
+                [
+                    'status' => 400,
+                    'missing_fields' => $validation['missing'],
+                ]
+            );
+        }
+
+        if (!empty($validation['type'])) {
+            return new WP_Error(
+                'rest_invalid_param',
+                'Tipos inválidos detectados.',
+                [
+                    'status' => 400,
+                    'type_errors' => $validation['type'],
+                ]
+            );
+        }
+
+        $response = [
+            'ok' => true,
+            'request_id' => 'TODO: request_id (ver Capa 3 — Validación, Firma Y Caducidad — V2, Observabilidad).',
+            'todo' => 'TODO: Respuesta detallada /verify (ver plugin-3-g3d-validate-sign.md §6.2).',
+        ];
+
+        return new WP_REST_Response($response, 200);
+    }
+}

--- a/plugins/g3d-validate-sign/src/Validation/RequestValidator.php
+++ b/plugins/g3d-validate-sign/src/Validation/RequestValidator.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\ValidateSign\Validation;
+
+use RuntimeException;
+
+class RequestValidator
+{
+    private array $schema;
+
+    public function __construct(string $schemaPath)
+    {
+        $schemaContents = file_get_contents($schemaPath);
+
+        if ($schemaContents === false) {
+            throw new RuntimeException('No se pudo leer el schema en ' . $schemaPath);
+        }
+
+        $decoded = json_decode($schemaContents, true);
+
+        if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+            throw new RuntimeException('Schema JSON inválido en ' . $schemaPath . ': ' . json_last_error_msg());
+        }
+
+        $this->schema = $decoded ?? [];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array{missing: string[], type: array<int, array{field: string, expected: string}>}
+     */
+    public function validate(array $data): array
+    {
+        $errors = [
+            'missing' => [],
+            'type' => [],
+        ];
+
+        $required = $this->schema['required'] ?? [];
+        $properties = $this->schema['properties'] ?? [];
+
+        foreach ($required as $field) {
+            if (!array_key_exists($field, $data)) {
+                $errors['missing'][] = (string) $field;
+            }
+        }
+
+        foreach ($properties as $field => $definition) {
+            if (!array_key_exists($field, $data)) {
+                continue;
+            }
+
+            if (!is_array($definition) || !isset($definition['type'])) {
+                continue;
+            }
+
+            $expectedType = $definition['type'];
+
+            if (!$this->isTypeValid($data[$field], $expectedType)) {
+                $errors['type'][] = [
+                    'field' => (string) $field,
+                    'expected' => is_array($expectedType) ? implode('|', $expectedType) : (string) $expectedType,
+                ];
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param mixed                 $value
+     * @param string|string[]|mixed $expected
+     */
+    private function isTypeValid(mixed $value, mixed $expected): bool
+    {
+        $types = is_array($expected) ? $expected : [$expected];
+
+        foreach ($types as $type) {
+            switch ($type) {
+                case 'string':
+                    if (is_string($value)) {
+                        return true;
+                    }
+
+                    break;
+                case 'integer':
+                    if (is_int($value)) {
+                        return true;
+                    }
+
+                    break;
+                case 'number':
+                    if (is_int($value) || is_float($value)) {
+                        return true;
+                    }
+
+                    break;
+                case 'boolean':
+                    if (is_bool($value)) {
+                        return true;
+                    }
+
+                    break;
+                case 'object':
+                    if (is_array($value)) {
+                        return true;
+                    }
+
+                    break;
+                case 'array':
+                    if (is_array($value)) {
+                        return true;
+                    }
+
+                    break;
+                case 'null':
+                    if ($value === null) {
+                        return true;
+                    }
+
+                    break;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- add JSON schema stubs for validate-sign and verify contracts based on the linked documentation
- implement a shared request validator and REST controllers with TODO placeholders pending business logic
- hook the plugin into g3d/v1 routes and update the README with pointers to the source specs

## Testing
- php -l plugins/g3d-validate-sign/src/Api/ValidateSignController.php
- php -l plugins/g3d-validate-sign/src/Api/VerifyController.php
- php -l plugins/g3d-validate-sign/src/Validation/RequestValidator.php


------
https://chatgpt.com/codex/tasks/task_e_68d9e7d48c0c832393c0c62401ebc0d3