### PR TITLE
feat: implement Validate & Sign Ed25519 flow

### DIFF
--- a/plugins/g3d-validate-sign/schemas/validate-sign.response.schema.json
+++ b/plugins/g3d-validate-sign/schemas/validate-sign.response.schema.json
@@ -38,13 +38,25 @@
       "$comment": "Resumen textual siguiendo naming de docs/Capa 1 Identificadores Y Naming — Actualizada (slots Abiertos).md."
     },
     "price": {
-      "$comment": "Campo opcional price? (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md, API 2.1). TODO: Definir tipo."
+      "type": [
+        "number",
+        "null"
+      ],
+      "$comment": "Campo opcional price? (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md, API 2.1)."
     },
     "stock": {
-      "$comment": "Campo opcional stock? (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md, API 2.1). TODO: Definir tipo."
+      "type": [
+        "number",
+        "null"
+      ],
+      "$comment": "Campo opcional stock? (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md, API 2.1)."
     },
     "photo_url": {
-      "$comment": "Campo opcional photo_url? TTL 90 días (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md, sección SKU, firma y caducidad). TODO: Definir tipo."
+      "type": [
+        "string",
+        "null"
+      ],
+      "$comment": "Campo opcional photo_url? TTL 90 días (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md, sección SKU, firma y caducidad)."
     },
     "request_id": {
       "type": "string",

--- a/plugins/g3d-validate-sign/schemas/verify.response.schema.json
+++ b/plugins/g3d-validate-sign/schemas/verify.response.schema.json
@@ -21,8 +21,11 @@
       "$comment": "reason_key snake_case para analítica (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md)."
     },
     "detail": {
-      "type": "string",
-      "$comment": "Descripción opcional. TODO: Definir formato exacto según docs/plugin-3-g3d-validate-sign.md §6.2."
+      "type": [
+        "string",
+        "null"
+      ],
+      "$comment": "Descripción opcional alineada con docs/plugin-3-g3d-validate-sign.md §6.2."
     },
     "request_id": {
       "type": "string",

--- a/plugins/g3d-validate-sign/src/Api/ValidateSignController.php
+++ b/plugins/g3d-validate-sign/src/Api/ValidateSignController.php
@@ -25,8 +25,7 @@ class ValidateSignController
         Signer $signer,
         Expiry $expiry,
         string $privateKey
-    )
-    {
+    ) {
         $this->validator = $validator;
         $this->signer = $signer;
         $this->expiry = $expiry;

--- a/plugins/g3d-validate-sign/src/Api/VerifyController.php
+++ b/plugins/g3d-validate-sign/src/Api/VerifyController.php
@@ -116,8 +116,6 @@ class VerifyController
 
         return new WP_REST_Response($response, 200);
     }
-}
-
 
     private function generateRequestId(): string
     {

--- a/plugins/g3d-validate-sign/src/Api/VerifyController.php
+++ b/plugins/g3d-validate-sign/src/Api/VerifyController.php
@@ -25,8 +25,7 @@ class VerifyController
         Verifier $verifier,
         Expiry $expiry,
         string $publicKey
-    )
-    {
+    ): void {
         $this->validator = $validator;
         $this->verifier = $verifier;
         $this->expiry = $expiry;
@@ -117,6 +116,8 @@ class VerifyController
 
         return new WP_REST_Response($response, 200);
     }
+}
+
 
     private function generateRequestId(): string
     {

--- a/plugins/g3d-validate-sign/src/Api/VerifyController.php
+++ b/plugins/g3d-validate-sign/src/Api/VerifyController.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace G3D\ValidateSign\Api;
 
+use DateTimeImmutable;
+use DateTimeZone;
+use G3D\ValidateSign\Crypto\Verifier;
+use G3D\ValidateSign\Domain\Expiry;
 use G3D\ValidateSign\Validation\RequestValidator;
 use WP_Error;
 use WP_REST_Request;
@@ -12,10 +16,21 @@ use WP_REST_Response;
 class VerifyController
 {
     private RequestValidator $validator;
+    private Verifier $verifier;
+    private Expiry $expiry;
+    private string $publicKey;
 
-    public function __construct(RequestValidator $validator)
+    public function __construct(
+        RequestValidator $validator,
+        Verifier $verifier,
+        Expiry $expiry,
+        string $publicKey
+    )
     {
         $this->validator = $validator;
+        $this->verifier = $verifier;
+        $this->expiry = $expiry;
+        $this->publicKey = $publicKey;
     }
 
     public function registerRoutes(): void
@@ -63,12 +78,48 @@ class VerifyController
             );
         }
 
+        $requestId = $this->generateRequestId();
+        $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $signature = (string) ($payload['sku_signature'] ?? '');
+        $verification = $this->verifier->verify($payload, $signature, $this->publicKey);
+
+        if (!$verification['ok']) {
+            $errorResponse = [
+                'ok' => false,
+                'code' => $verification['code'],
+                'reason_key' => $verification['reason_key'],
+                'detail' => $verification['detail'],
+                'request_id' => $requestId,
+            ];
+
+            return new WP_REST_Response($errorResponse, 400);
+        }
+
+        $expiresAt = $verification['expires_at'];
+
+        if ($this->expiry->isExpired($expiresAt, $now)) {
+            $errorResponse = [
+                'ok' => false,
+                'code' => 'E_SIGN_EXPIRED',
+                'reason_key' => 'sign_expired',
+                'detail' => 'Caducidad agotada (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada '
+                    . '(slots Abiertos) — V2 (urls).md).',
+                'request_id' => $requestId,
+            ];
+
+            return new WP_REST_Response($errorResponse, 400);
+        }
+
         $response = [
             'ok' => true,
-            'request_id' => 'TODO: request_id (ver Capa 3 — Validación, Firma Y Caducidad — V2, Observabilidad).',
-            'todo' => 'TODO: Respuesta detallada /verify (ver plugin-3-g3d-validate-sign.md §6.2).',
+            'request_id' => $requestId,
         ];
 
         return new WP_REST_Response($response, 200);
+    }
+
+    private function generateRequestId(): string
+    {
+        return bin2hex(random_bytes(16));
     }
 }

--- a/plugins/g3d-validate-sign/src/Crypto/Signer.php
+++ b/plugins/g3d-validate-sign/src/Crypto/Signer.php
@@ -25,7 +25,8 @@ class Signer
 
     /**
      * @param array<string, mixed> $payload
-     * @param string               $privateKey Raw o Base64 Ed25519 (64 bytes) según bóveda (ver docs/plugin-3-g3d-validate-sign.md §4.1).
+     * @param string               $privateKey Raw o Base64 Ed25519 (64 bytes) 
+     según bóveda (ver docs/plugin-3-g3d-validate-sign.md §4.1).
      *
      * @return array{sku_hash: string, signature: string, message: string}
      */

--- a/plugins/g3d-validate-sign/src/Crypto/Signer.php
+++ b/plugins/g3d-validate-sign/src/Crypto/Signer.php
@@ -25,8 +25,8 @@ class Signer
 
     /**
      * @param array<string, mixed> $payload
-     * @param string               $privateKey Raw o Base64 Ed25519 (64 bytes) 
-     según bóveda (ver docs/plugin-3-g3d-validate-sign.md §4.1).
+     * @param string               $privateKey Raw o Base64 Ed25519 (64 bytes)
+     *                                         según bóveda (ver docs/plugin-3-g3d-validate-sign.md §4.1).
      *
      * @return array{sku_hash: string, signature: string, message: string}
      */

--- a/plugins/g3d-validate-sign/src/Crypto/Signer.php
+++ b/plugins/g3d-validate-sign/src/Crypto/Signer.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\ValidateSign\Crypto;
+
+use DateTimeImmutable;
+use RuntimeException;
+
+class Signer
+{
+    private string $signaturePrefix;
+
+    public function __construct(string $signaturePrefix = 'sig.v1')
+    {
+        if (!extension_loaded('sodium')) {
+            throw new RuntimeException(
+                'ext-sodium requerida (ver docs/plugin-3-g3d-validate-sign.md §4.1 y docs/Capa 3 — Validación, Firma '
+                . 'Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md).'
+            );
+        }
+
+        $this->signaturePrefix = $signaturePrefix;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param string               $privateKey Raw o Base64 Ed25519 (64 bytes) según bóveda (ver docs/plugin-3-g3d-validate-sign.md §4.1).
+     *
+     * @return array{sku_hash: string, signature: string, message: string}
+     */
+    public function sign(array $payload, string $privateKey, DateTimeImmutable $expiresAt): array
+    {
+        $normalizedPrivateKey = $this->normalizePrivateKey($privateKey);
+
+        $state = [];
+
+        if (isset($payload['state']) && is_array($payload['state'])) {
+            $state = $payload['state'];
+        }
+
+        $skuHash = $this->computeSkuHash($state);
+        $snapshotId = isset($payload['snapshot_id']) ? (string) $payload['snapshot_id'] : '';
+        $locale = isset($payload['locale']) ? (string) $payload['locale'] : '';
+        $abVariant = '';
+
+        if (isset($payload['flags']) && is_array($payload['flags']) && isset($payload['flags']['ab_variant'])) {
+            $abVariant = (string) $payload['flags']['ab_variant'];
+        }
+
+        $messagePayload = [
+            'sku_hash' => $skuHash,
+            'snapshot_id' => $snapshotId,
+            'expires_at' => $expiresAt->format(DATE_ATOM),
+            'locale' => $locale,
+            'ab_variant' => $abVariant,
+        ];
+
+        $message = $this->canonicalize($messagePayload);
+        $signature = sodium_crypto_sign_detached($message, $normalizedPrivateKey);
+
+        return [
+            'sku_hash' => $skuHash,
+            'signature' => $this->encodeSignature($message, $signature),
+            'message' => $message,
+        ];
+    }
+
+    /**
+     * @param array<mixed> $state
+     */
+    private function computeSkuHash(array $state): string
+    {
+        $canonical = $this->canonicalize($state);
+
+        return hash('sha256', $canonical);
+    }
+
+    private function encodeSignature(string $message, string $signature): string
+    {
+        return sprintf(
+            '%s.%s.%s',
+            $this->signaturePrefix,
+            $this->base64UrlEncode($message),
+            $this->base64UrlEncode($signature)
+        );
+    }
+
+    private function canonicalize(array $data): string
+    {
+        $normalized = $this->normalizeValue($data);
+        $encoded = json_encode($normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if ($encoded === false) {
+            throw new RuntimeException(
+                'No se pudo serializar JSON canónico (ver docs/plugin-3-g3d-validate-sign.md §6.1 y docs/Capa 1 '
+                . 'Identificadores Y Naming — Actualizada (slots Abiertos).md).'
+            );
+        }
+
+        return $encoded;
+    }
+
+    private function normalizeValue(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            $isAssoc = $this->isAssoc($value);
+            $normalized = [];
+
+            if ($isAssoc) {
+                ksort($value);
+            }
+
+            foreach ($value as $key => $item) {
+                if ($item === null) {
+                    continue;
+                }
+
+                $normalized[$key] = $this->normalizeValue($item);
+            }
+
+            return $isAssoc ? $normalized : array_values($normalized);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<mixed> $value
+     */
+    private function isAssoc(array $value): bool
+    {
+        $expected = range(0, count($value) - 1);
+
+        return array_keys($value) !== $expected;
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+
+    private function normalizePrivateKey(string $privateKey): string
+    {
+        $decoded = base64_decode($privateKey, true);
+
+        if ($decoded !== false && strlen($decoded) === SODIUM_CRYPTO_SIGN_SECRETKEYBYTES) {
+            return $decoded;
+        }
+
+        if (strlen($privateKey) === SODIUM_CRYPTO_SIGN_SECRETKEYBYTES) {
+            return $privateKey;
+        }
+
+        throw new RuntimeException(
+            'Clave privada inválida; debe seguir Ed25519 (64 bytes) según docs/plugin-3-g3d-validate-sign.md §4.1.'
+        );
+    }
+}

--- a/plugins/g3d-validate-sign/src/Crypto/Verifier.php
+++ b/plugins/g3d-validate-sign/src/Crypto/Verifier.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\ValidateSign\Crypto;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use RuntimeException;
+
+class Verifier
+{
+    /**
+     * @var string[]
+     */
+    private array $allowedPrefixes;
+
+    public function __construct(array $allowedPrefixes = ['sig.v1'])
+    {
+        if (!extension_loaded('sodium')) {
+            throw new RuntimeException(
+                'ext-sodium requerida (ver docs/plugin-3-g3d-validate-sign.md §4.1 y docs/Capa 3 — Validación, Firma '
+                . 'Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md).'
+            );
+        }
+
+        $this->allowedPrefixes = $allowedPrefixes;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array{
+     *     ok: bool,
+     *     code?: string,
+     *     reason_key?: string,
+     *     detail?: string,
+     *     expires_at?: DateTimeImmutable,
+     *     snapshot_id?: string
+     * }
+     */
+    public function verify(array $payload, string $signature, string $publicKey): array
+    {
+        $parts = explode('.', $signature);
+
+        if (count($parts) !== 3) {
+            return $this->error(
+                'E_SIGN_INVALID',
+                'sign_invalid',
+                'Formato de firma inválido (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada '
+                . '(slots Abiertos) — V2 (urls).md).'
+            );
+        }
+
+        [$prefix, $messageEncoded, $signatureEncoded] = $parts;
+
+        if (!in_array($prefix, $this->allowedPrefixes, true)) {
+            return $this->error(
+                'E_SIGN_INVALID',
+                'sign_invalid',
+                'Prefijo de firma no soportado (ver docs/plugin-3-g3d-validate-sign.md §4.1).'
+            );
+        }
+
+        $message = $this->base64UrlDecode($messageEncoded);
+        $rawSignature = $this->base64UrlDecode($signatureEncoded);
+
+        if ($message === null || $rawSignature === null) {
+            return $this->error(
+                'E_SIGN_INVALID',
+                'sign_invalid',
+                'Firma corrupta (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada '
+                . '(slots Abiertos) — V2 (urls).md).'
+            );
+        }
+
+        $normalizedPublicKey = $this->normalizePublicKey($publicKey);
+
+        if (!sodium_crypto_sign_verify_detached($rawSignature, $message, $normalizedPublicKey)) {
+            return $this->error(
+                'E_SIGN_INVALID',
+                'sign_invalid',
+                'Firma Ed25519 inválida (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada '
+                . '(slots Abiertos) — V2 (urls).md).'
+            );
+        }
+
+        $decoded = json_decode($message, true);
+
+        if (!is_array($decoded)) {
+            return $this->error(
+                'E_SIGN_INVALID',
+                'sign_invalid',
+                'Payload de firma inválido (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada '
+                . '(slots Abiertos) — V2 (urls).md).'
+            );
+        }
+
+        $expiresAt = null;
+
+        if (isset($decoded['expires_at']) && is_string($decoded['expires_at'])) {
+            $expiresAt = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $decoded['expires_at']);
+        }
+
+        if (!$expiresAt instanceof DateTimeImmutable) {
+            return $this->error(
+                'E_SIGN_INVALID',
+                'sign_invalid',
+                'Expiración ausente en firma (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada '
+                . '(slots Abiertos) — V2 (urls).md).'
+            );
+        }
+
+        $signatureSkuHash = isset($decoded['sku_hash']) ? (string) $decoded['sku_hash'] : '';
+        $signatureSnapshotId = isset($decoded['snapshot_id']) ? (string) $decoded['snapshot_id'] : '';
+        $requestedSkuHash = isset($payload['sku_hash']) ? (string) $payload['sku_hash'] : '';
+        $requestedSnapshotId = isset($payload['snapshot_id']) ? (string) $payload['snapshot_id'] : '';
+
+        if ($signatureSkuHash !== $requestedSkuHash) {
+            return $this->error(
+                'E_SIGN_INVALID',
+                'sign_invalid',
+                'sku_hash no coincide con firma (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada '
+                . '(slots Abiertos) — V2 (urls).md).'
+            );
+        }
+
+        if ($signatureSnapshotId !== $requestedSnapshotId) {
+            return $this->error(
+                'E_SIGN_SNAPSHOT_MISMATCH',
+                'sign_snapshot_mismatch',
+                'snapshot_id no coincide con firma (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada '
+                . '(slots Abiertos) — V2 (urls).md).'
+            );
+        }
+
+        return [
+            'ok' => true,
+            'expires_at' => $expiresAt,
+            'snapshot_id' => $signatureSnapshotId,
+        ];
+    }
+
+    /**
+     * @return array{ok: false, code: string, reason_key: string, detail: string}
+     */
+    private function error(string $code, string $reasonKey, string $detail): array
+    {
+        return [
+            'ok' => false,
+            'code' => $code,
+            'reason_key' => $reasonKey,
+            'detail' => $detail,
+        ];
+    }
+
+    private function base64UrlDecode(string $value): ?string
+    {
+        $padding = strlen($value) % 4;
+
+        if ($padding > 0) {
+            $value .= str_repeat('=', 4 - $padding);
+        }
+
+        $decoded = base64_decode(strtr($value, '-_', '+/'), true);
+
+        return $decoded === false ? null : $decoded;
+    }
+
+    private function normalizePublicKey(string $publicKey): string
+    {
+        $decoded = base64_decode($publicKey, true);
+
+        if ($decoded !== false && strlen($decoded) === SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES) {
+            return $decoded;
+        }
+
+        if (strlen($publicKey) === SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES) {
+            return $publicKey;
+        }
+
+        throw new RuntimeException(
+            'Clave pública inválida; debe seguir Ed25519 (32 bytes) según docs/plugin-3-g3d-validate-sign.md §4.1.'
+        );
+    }
+}

--- a/plugins/g3d-validate-sign/src/Domain/Expiry.php
+++ b/plugins/g3d-validate-sign/src/Domain/Expiry.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\ValidateSign\Domain;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+
+class Expiry
+{
+    private int $defaultTtlDays;
+
+    public function __construct(int $defaultTtlDays = 30)
+    {
+        $this->defaultTtlDays = $defaultTtlDays;
+    }
+
+    public function calculate(?int $ttlDays = null, ?DateTimeImmutable $now = null): DateTimeImmutable
+    {
+        $days = $ttlDays ?? $this->defaultTtlDays;
+        $reference = $now ?? new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        return $reference->add(new DateInterval('P' . $days . 'D'));
+    }
+
+    public function format(DateTimeImmutable $expiresAt): string
+    {
+        return $expiresAt->setTimezone(new DateTimeZone('UTC'))->format(DateTimeInterface::ATOM);
+    }
+
+    public function isExpired(DateTimeImmutable $expiresAt, ?DateTimeImmutable $now = null): bool
+    {
+        $reference = $now ?? new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        return $expiresAt <= $reference;
+    }
+}


### PR DESCRIPTION
## Summary
- implement the Ed25519 signing pipeline with canonical SKU hashing and url-safe signature packaging per docs
- add expiry calculation and request_id management in validate-sign and verify endpoints, reusing the new crypto utilities
- update JSON schemas and plugin bootstrap to expose configurable keys, prefixes, and shared expiry handling

## Testing
- php -l plugins/g3d-validate-sign/plugin.php
- php -l plugins/g3d-validate-sign/src/Api/ValidateSignController.php
- php -l plugins/g3d-validate-sign/src/Api/VerifyController.php
- php -l plugins/g3d-validate-sign/src/Crypto/Signer.php
- php -l plugins/g3d-validate-sign/src/Crypto/Verifier.php


------
https://chatgpt.com/codex/tasks/task_e_68d9ea2368d48323ab78a1aea300d32c