### PR TITLE
Add asset placeholders for wizard modal plugin

### DIFF
--- a/plugins/gafas3d-wizard-modal/assets/css/.keep
+++ b/plugins/gafas3d-wizard-modal/assets/css/.keep
@@ -1,0 +1,1 @@
+# Placeholder to retain CSS directory structure for the wizard modal plugin.

--- a/plugins/gafas3d-wizard-modal/assets/js/.keep
+++ b/plugins/gafas3d-wizard-modal/assets/js/.keep
@@ -1,0 +1,1 @@
+# Placeholder to retain JS directory structure for the wizard modal plugin.


### PR DESCRIPTION
## Summary
- add placeholder .keep files to retain JS and CSS asset directories for the wizard modal plugin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da0f59f74c8323b06d08b957bfb567