### PR TITLE
feat: add wizard modal UI shell scaffolding

### DIFF
--- a/plugins/gafas3d-wizard-modal/README.md
+++ b/plugins/gafas3d-wizard-modal/README.md
@@ -1,2 +1,5 @@
-# Esqueleto del plugin
-Este directorio corresponde al plugin. Aún sin código: se añadirá en fases.
+# Gafas3D Wizard Modal — UI shell
+
+- [docs/Plugin 4 — Gafas3d Wizard Modal (ui_ux + Visor + Zero-mensajes) — Informe.md](../docs/plugin-4-gafas3d-wizard-modal.md)
+- [docs/Capa 4 — Ui_ux Orquestación — Addenda Aplicada 2025-09-27.md](../docs/Capa%204%20%E2%80%94%20Ui_ux%20Orquestaci%C3%B3n%20%E2%80%94%20Addenda%20Aplicada%202025-09-27.md)
+- [docs/Capa 1 Identificadores Y Naming — Actualizada (slots Abiertos).md](../docs/Capa%201%20Identificadores%20Y%20Naming%20%E2%80%94%20Actualizada%20(slots%20Abiertos).md)

--- a/plugins/gafas3d-wizard-modal/assets/css/wizard.css
+++ b/plugins/gafas3d-wizard-modal/assets/css/wizard.css
@@ -1,0 +1,79 @@
+.g3d-wizard-modal__overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(17, 24, 39, 0.56);
+    padding: 2rem;
+    z-index: 100000;
+}
+
+.g3d-wizard-modal__overlay[hidden] {
+    display: none;
+}
+
+.g3d-wizard-modal {
+    background-color: #ffffff;
+    color: #111827;
+    width: min(960px, 90vw);
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    border-radius: 1rem;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.25);
+    outline: none;
+}
+
+.g3d-wizard-modal__content {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: 2rem;
+    overflow: hidden;
+}
+
+.g3d-wizard-modal__header,
+.g3d-wizard-modal__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.g3d-wizard-modal__step-list {
+    display: flex;
+    gap: 0.75rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.g3d-wizard-modal__panel {
+    border: 1px dashed rgba(17, 24, 39, 0.24);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+}
+
+.g3d-wizard-modal__close,
+.g3d-wizard-modal__open,
+.g3d-wizard-modal__cta,
+.g3d-wizard-modal__step-button {
+    cursor: pointer;
+}
+
+.g3d-wizard-modal__close {
+    border: none;
+    background: transparent;
+    font-size: 1.5rem;
+    line-height: 1;
+}
+
+.g3d-wizard-modal__cta {
+    padding: 0.75rem 1.5rem;
+    border-radius: 9999px;
+    border: none;
+    background-color: #111827;
+    color: #ffffff;
+}

--- a/plugins/gafas3d-wizard-modal/assets/js/wizard.js
+++ b/plugins/gafas3d-wizard-modal/assets/js/wizard.js
@@ -1,0 +1,92 @@
+(function () {
+    const focusableSelectors = [
+        'a[href]',
+        'area[href]',
+        'button:not([disabled])',
+        'input:not([disabled]):not([type="hidden"])',
+        'select:not([disabled])',
+        'textarea:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])'
+    ];
+
+    const docRef = 'docs/plugin-4-gafas3d-wizard-modal.md §5';
+
+    const overlay = document.querySelector('[data-g3d-wizard-modal-overlay]');
+    const dialog = overlay ? overlay.querySelector('[role="dialog"]') : null;
+    const openButton = document.querySelector('[data-g3d-wizard-modal-open]');
+    const closeButton = overlay ? overlay.querySelector('[data-g3d-wizard-modal-close]') : null;
+    let lastFocusedElement = null;
+
+    if (!overlay || !dialog || !openButton || !closeButton) {
+        console.warn('TODO: Completar markup para el modal. Ver ' + docRef);
+        return;
+    }
+
+    function getFocusableElements() {
+        return Array.from(
+            dialog.querySelectorAll(focusableSelectors.join(','))
+        ).filter(function (element) {
+            return element.offsetParent !== null || element === closeButton;
+        });
+    }
+
+    function trapFocus(event) {
+        if (overlay.hasAttribute('hidden') || event.key !== 'Tab') {
+            return;
+        }
+
+        const focusable = getFocusableElements();
+        if (!focusable.length) {
+            event.preventDefault();
+            dialog.focus({ preventScroll: true });
+            return;
+        }
+
+        const firstElement = focusable[0];
+        const lastElement = focusable[focusable.length - 1];
+
+        if (event.shiftKey && document.activeElement === firstElement) {
+            event.preventDefault();
+            lastElement.focus();
+        } else if (!event.shiftKey && document.activeElement === lastElement) {
+            event.preventDefault();
+            firstElement.focus();
+        }
+    }
+
+    function onKeyDown(event) {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            closeModal();
+            return;
+        }
+
+        trapFocus(event);
+    }
+
+    function openModal() {
+        overlay.removeAttribute('hidden');
+        lastFocusedElement = document.activeElement;
+
+        const focusable = getFocusableElements();
+        if (focusable.length) {
+            focusable[0].focus();
+        } else {
+            dialog.focus({ preventScroll: true });
+        }
+
+        document.addEventListener('keydown', onKeyDown);
+    }
+
+    function closeModal() {
+        overlay.setAttribute('hidden', '');
+        document.removeEventListener('keydown', onKeyDown);
+
+        if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+            lastFocusedElement.focus();
+        }
+    }
+
+    openButton.addEventListener('click', openModal);
+    closeButton.addEventListener('click', closeModal);
+})();

--- a/plugins/gafas3d-wizard-modal/plugin.php
+++ b/plugins/gafas3d-wizard-modal/plugin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Plugin Name: Gafas3D Wizard Modal
  * Description: Esqueleto inicial (sin lógica). Ver docs/ para funciones y contratos.

--- a/plugins/gafas3d-wizard-modal/plugin.php
+++ b/plugins/gafas3d-wizard-modal/plugin.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Plugin Name: Gafas3D Wizard Modal
  * Description: Esqueleto inicial (sin lógica). Ver docs/ para funciones y contratos.
@@ -11,17 +10,54 @@
  * Text Domain: gafas3d-wizard-modal
  */
 
+declare(strict_types=1);
+
+use Gafas3d\WizardModal\Admin\Page;
+
 if (!defined('ABSPATH')) {
     exit;
 }
 
-register_activation_hook(__FILE__, function () {
+require_once __DIR__ . '/src/Admin/Page.php';
+require_once __DIR__ . '/src/UI/Modal.php';
+
+register_activation_hook(__FILE__, static function (): void {
     // Placeholder de activación (nop).
 });
-register_deactivation_hook(__FILE__, function () {
+
+register_deactivation_hook(__FILE__, static function (): void {
     // Placeholder de desactivación (nop).
 });
 
-add_action('init', function () {
-    load_plugin_textdomain('gafas3d-wizard-modal', false, dirname(plugin_basename(__FILE__)) . '/languages');
+add_action('init', static function (): void {
+    load_plugin_textdomain(
+        'gafas3d-wizard-modal',
+        false,
+        dirname(plugin_basename(__FILE__)) . '/languages'
+    );
+});
+
+add_action('admin_menu', static function (): void {
+    Page::register();
+});
+
+add_action('admin_enqueue_scripts', static function (string $hook): void {
+    if ($hook !== 'toplevel_page_g3d-wizard') {
+        return;
+    }
+
+    wp_enqueue_style(
+        'gafas3d-wizard-modal',
+        plugins_url('assets/css/wizard.css', __FILE__),
+        [],
+        '0.1.0'
+    );
+
+    wp_enqueue_script(
+        'gafas3d-wizard-modal',
+        plugins_url('assets/js/wizard.js', __FILE__),
+        [],
+        '0.1.0',
+        true
+    );
 });

--- a/plugins/gafas3d-wizard-modal/src/Admin/Page.php
+++ b/plugins/gafas3d-wizard-modal/src/Admin/Page.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Gafas3d\WizardModal\Admin;

--- a/plugins/gafas3d-wizard-modal/src/Admin/Page.php
+++ b/plugins/gafas3d-wizard-modal/src/Admin/Page.php
@@ -1,5 +1,6 @@
 <?php
 
+
 declare(strict_types=1);
 
 namespace Gafas3d\WizardModal\Admin;

--- a/plugins/gafas3d-wizard-modal/src/Admin/Page.php
+++ b/plugins/gafas3d-wizard-modal/src/Admin/Page.php
@@ -1,6 +1,4 @@
 <?php
-
-
 declare(strict_types=1);
 
 namespace Gafas3d\WizardModal\Admin;
@@ -34,7 +32,7 @@ final class Page
     {
         echo '<div id="gafas3d-wizard-modal-root" class="gafas3d-wizard-modal-root">';
         echo '<!-- TODO: Definir IDs y clases exactos del contenedor raíz. Ver docs/plugin-4-gafas3d-wizard-modal.md §5.1. -->';
-        Modal::render();
-        echo '</div>';
+ Modal::render();
+ echo '</div>';
     }
 }

--- a/plugins/gafas3d-wizard-modal/src/Admin/Page.php
+++ b/plugins/gafas3d-wizard-modal/src/Admin/Page.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gafas3d\WizardModal\Admin;
+
+use Gafas3d\WizardModal\UI\Modal;
+use function add_menu_page;
+use function __;
+
+final class Page
+{
+    public const MENU_SLUG = 'g3d-wizard';
+
+    private function __construct()
+    {
+    }
+
+    public static function register(): void
+    {
+        add_menu_page(
+            __('Gafas3D Wizard Modal', 'gafas3d-wizard-modal'),
+            __('Gafas3D Wizard Modal', 'gafas3d-wizard-modal'),
+            'manage_options',
+            self::MENU_SLUG,
+            [self::class, 'render'],
+            '',
+            82
+        );
+    }
+
+    public static function render(): void
+    {
+        echo '<div id="gafas3d-wizard-modal-root" class="gafas3d-wizard-modal-root">';
+        echo '<!-- TODO: Definir IDs y clases exactos del contenedor raíz. Ver docs/plugin-4-gafas3d-wizard-modal.md §5.1. -->';
+        Modal::render();
+        echo '</div>';
+    }
+}

--- a/plugins/gafas3d-wizard-modal/src/Admin/Page.php
+++ b/plugins/gafas3d-wizard-modal/src/Admin/Page.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Gafas3d\WizardModal\Admin;
 
 use Gafas3d\WizardModal\UI\Modal;
+
 use function add_menu_page;
 use function __;
 
@@ -31,8 +32,12 @@ final class Page
     public static function render(): void
     {
         echo '<div id="gafas3d-wizard-modal-root" class="gafas3d-wizard-modal-root">';
-        echo '<!-- TODO: Definir IDs y clases exactos del contenedor raíz. Ver docs/plugin-4-gafas3d-wizard-modal.md §5.1. -->';
- Modal::render();
- echo '</div>';
+
+        echo '<!-- TODO: Definir IDs y clases exactos del contenedor raíz. '
+            . 'Ver docs/plugin-4-gafas3d-wizard-modal.md §5.1. -->';
+
+        Modal::render();
+
+        echo '</div>';
     }
 }

--- a/plugins/gafas3d-wizard-modal/src/UI/Modal.php
+++ b/plugins/gafas3d-wizard-modal/src/UI/Modal.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gafas3d\WizardModal\UI;
+
+use function esc_attr;
+use function esc_attr__;
+use function esc_html;
+use function esc_html__;
+use function printf;
+
+final class Modal
+{
+    private const STEP_LABELS = [
+        'pieza' => 'Pieza',
+        'material' => 'Material',
+        'modelo' => 'Modelo',
+        'color' => 'Color',
+        'textura' => 'Textura',
+        'acabado' => 'Acabado',
+    ];
+
+    private function __construct()
+    {
+    }
+
+    public static function render(): void
+    {
+        echo '<button type="button" class="g3d-wizard-modal__open" data-g3d-wizard-modal-open>';
+        echo esc_html__(
+            'TODO: Definir etiqueta para abrir el wizard. Ver docs/plugin-4-gafas3d-wizard-modal.md §5.1.',
+            'gafas3d-wizard-modal'
+        );
+        echo '</button>';
+
+        echo '<div class="g3d-wizard-modal__overlay" data-g3d-wizard-modal-overlay hidden>';
+        echo '<div class="g3d-wizard-modal" role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="g3d-wizard-modal-title" aria-describedby="g3d-wizard-modal-description">';
+        echo '<div tabindex="0" data-g3d-wizard-focus-guard="start"></div>';
+        echo '<div class="g3d-wizard-modal__content">';
+        echo '<header class="g3d-wizard-modal__header">';
+        echo '<h1 id="g3d-wizard-modal-title" class="g3d-wizard-modal__title">';
+        echo esc_html__(
+            'TODO: Título del wizard. Ver docs/plugin-4-gafas3d-wizard-modal.md §5.1.',
+            'gafas3d-wizard-modal'
+        );
+        echo '</h1>';
+        echo '<p id="g3d-wizard-modal-description" class="g3d-wizard-modal__description">';
+        echo esc_html__(
+            'TODO: Descripción inicial. Ver docs/plugin-4-gafas3d-wizard-modal.md §5.1.',
+            'gafas3d-wizard-modal'
+        );
+        echo '</p>';
+        echo '<button type="button" class="g3d-wizard-modal__close" data-g3d-wizard-modal-close aria-label="';
+        echo esc_attr__(
+            'TODO: Etiqueta aria para cerrar. Ver docs/plugin-4-gafas3d-wizard-modal.md §5.1.',
+            'gafas3d-wizard-modal'
+        );
+        echo '">×</button>';
+        echo '</header>';
+
+        echo '<nav class="g3d-wizard-modal__steps" aria-label="';
+        echo esc_attr__(
+            'TODO: Etiqueta navegación de pasos. Ver docs/plugin-4-gafas3d-wizard-modal.md §5.2.',
+            'gafas3d-wizard-modal'
+        );
+        echo '">';
+        echo '<ul role="tablist" class="g3d-wizard-modal__step-list">';
+
+        foreach (self::STEP_LABELS as $slug => $label) {
+            $tabId = 'g3d-wizard-tab-' . $slug;
+            $panelId = 'g3d-wizard-panel-' . $slug;
+
+            echo '<li class="g3d-wizard-modal__step">';
+            echo '<button type="button" role="tab" aria-selected="false" tabindex="-1" id="' . esc_attr($tabId) . '" aria-controls="' . esc_attr($panelId) . '" class="g3d-wizard-modal__step-button" data-g3d-wizard-step="' . esc_attr($slug) . '">';
+            echo esc_html__($label, 'gafas3d-wizard-modal');
+            echo '</button>';
+            echo '</li>';
+        }
+
+        echo '</ul>';
+        echo '</nav>';
+
+        foreach (self::STEP_LABELS as $slug => $label) {
+            $panelId = 'g3d-wizard-panel-' . $slug;
+            $tabId = 'g3d-wizard-tab-' . $slug;
+
+            echo '<section role="tabpanel" aria-labelledby="' . esc_attr($tabId) . '" id="' . esc_attr($panelId) . '" class="g3d-wizard-modal__panel" hidden>';
+            echo '<p class="g3d-wizard-modal__panel-placeholder">';
+            printf(
+                /* translators: %s: nombre del paso definido en docs/plugin-4-gafas3d-wizard-modal.md §5 */
+                esc_html__(
+                    'TODO: Contenido para el paso %s. Ver docs/plugin-4-gafas3d-wizard-modal.md §5.',
+                    'gafas3d-wizard-modal'
+                ),
+                esc_html($label)
+            );
+            echo '</p>';
+            echo '</section>';
+        }
+
+        echo '<footer class="g3d-wizard-modal__footer">';
+        echo '<div class="g3d-wizard-modal__summary" aria-live="polite">';
+        echo esc_html__(
+            'TODO: Resumen del estado. Ver docs/plugin-4-gafas3d-wizard-modal.md §5.5.',
+            'gafas3d-wizard-modal'
+        );
+        echo '</div>';
+        echo '<button type="button" class="g3d-wizard-modal__cta" data-g3d-wizard-modal-cta>';
+        echo esc_html__(
+            'TODO: Texto del CTA. Ver docs/plugin-4-gafas3d-wizard-modal.md §5.6.',
+            'gafas3d-wizard-modal'
+        );
+        echo '</button>';
+        echo '</footer>';
+
+        echo '</div>';
+        echo '<div tabindex="0" data-g3d-wizard-focus-guard="end"></div>';
+        echo '</div>';
+        echo '</div>';
+    }
+}

--- a/plugins/gafas3d-wizard-modal/src/UI/Modal.php
+++ b/plugins/gafas3d-wizard-modal/src/UI/Modal.php
@@ -35,9 +35,14 @@ final class Modal
         echo '</button>';
 
         echo '<div class="g3d-wizard-modal__overlay" data-g3d-wizard-modal-overlay hidden>';
-        echo '<div class="g3d-wizard-modal" role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="g3d-wizard-modal-title" aria-describedby="g3d-wizard-modal-description">';
+
+        echo '<div class="g3d-wizard-modal" role="dialog" tabindex="-1" aria-modal="true" '
+            . 'aria-labelledby="g3d-wizard-modal-title" '
+            . 'aria-describedby="g3d-wizard-modal-description">';
+
         echo '<div tabindex="0" data-g3d-wizard-focus-guard="start"></div>';
         echo '<div class="g3d-wizard-modal__content">';
+
         echo '<header class="g3d-wizard-modal__header">';
         echo '<h1 id="g3d-wizard-modal-title" class="g3d-wizard-modal__title">';
         echo esc_html__(
@@ -45,12 +50,14 @@ final class Modal
             'gafas3d-wizard-modal'
         );
         echo '</h1>';
+
         echo '<p id="g3d-wizard-modal-description" class="g3d-wizard-modal__description">';
         echo esc_html__(
             'TODO: Descripción inicial. Ver docs/plugin-4-gafas3d-wizard-modal.md §5.1.',
             'gafas3d-wizard-modal'
         );
         echo '</p>';
+
         echo '<button type="button" class="g3d-wizard-modal__close" data-g3d-wizard-modal-close aria-label="';
         echo esc_attr__(
             'TODO: Etiqueta aria para cerrar. Ver docs/plugin-4-gafas3d-wizard-modal.md §5.1.',
@@ -65,6 +72,7 @@ final class Modal
             'gafas3d-wizard-modal'
         );
         echo '">';
+
         echo '<ul role="tablist" class="g3d-wizard-modal__step-list">';
 
         foreach (self::STEP_LABELS as $slug => $label) {
@@ -72,7 +80,15 @@ final class Modal
             $panelId = 'g3d-wizard-panel-' . $slug;
 
             echo '<li class="g3d-wizard-modal__step">';
-            echo '<button type="button" role="tab" aria-selected="false" tabindex="-1" id="' . esc_attr($tabId) . '" aria-controls="' . esc_attr($panelId) . '" class="g3d-wizard-modal__step-button" data-g3d-wizard-step="' . esc_attr($slug) . '">';
+
+            echo '<button type="button" role="tab" aria-selected="false" tabindex="-1" id="'
+                . esc_attr($tabId)
+                . '" aria-controls="'
+                . esc_attr($panelId)
+                . '" class="g3d-wizard-modal__step-button" data-g3d-wizard-step="'
+                . esc_attr($slug)
+                . '">';
+
             echo esc_html__($label, 'gafas3d-wizard-modal');
             echo '</button>';
             echo '</li>';
@@ -85,7 +101,12 @@ final class Modal
             $panelId = 'g3d-wizard-panel-' . $slug;
             $tabId = 'g3d-wizard-tab-' . $slug;
 
-            echo '<section role="tabpanel" aria-labelledby="' . esc_attr($tabId) . '" id="' . esc_attr($panelId) . '" class="g3d-wizard-modal__panel" hidden>';
+            echo '<section role="tabpanel" aria-labelledby="'
+                . esc_attr($tabId)
+                . '" id="'
+                . esc_attr($panelId)
+                . '" class="g3d-wizard-modal__panel" hidden>';
+
             echo '<p class="g3d-wizard-modal__panel-placeholder">';
             printf(
                 /* translators: %s: nombre del paso definido en docs/plugin-4-gafas3d-wizard-modal.md §5 */
@@ -106,17 +127,19 @@ final class Modal
             'gafas3d-wizard-modal'
         );
         echo '</div>';
+
         echo '<button type="button" class="g3d-wizard-modal__cta" data-g3d-wizard-modal-cta>';
         echo esc_html__(
             'TODO: Texto del CTA. Ver docs/plugin-4-gafas3d-wizard-modal.md §5.6.',
             'gafas3d-wizard-modal'
         );
         echo '</button>';
+
         echo '</footer>';
 
-        echo '</div>';
+        echo '</div>'; // .g3d-wizard-modal__content
         echo '<div tabindex="0" data-g3d-wizard-focus-guard="end"></div>';
-        echo '</div>';
-        echo '</div>';
+        echo '</div>'; // .g3d-wizard-modal
+        echo '</div>'; // .g3d-wizard-modal__overlay
     }
 }


### PR DESCRIPTION
## Summary
- register the admin wizard page, load translations, and enqueue the modal shell assets only on the wizard screen
- scaffold the admin page container and accessible modal markup for the six documented steps with TODO notes pointing back to the specification
- add the minimal JS/CSS required to open/close the modal with focus trapping and document pointers in the README

## Testing
- php -l plugins/gafas3d-wizard-modal/plugin.php
- php -l plugins/gafas3d-wizard-modal/src/Admin/Page.php
- php -l plugins/gafas3d-wizard-modal/src/UI/Modal.php

------
https://chatgpt.com/codex/tasks/task_e_68da10fb7624832384071fa1a5a39685