### PR TITLE
refactor: split Audit contracts interfaces into individual files

### DIFF
--- a/plugins/g3d-admin-ops/README.md
+++ b/plugins/g3d-admin-ops/README.md
@@ -1,2 +1,7 @@
-# Esqueleto del plugin
-Este directorio corresponde al plugin. Aún sin código: se añadirá en fases.
+# G3D Admin & Ops
+
+Esqueleto del plugin. Consultar la documentación fuente para requisitos y contratos:
+
+- docs/Plugin 5 — G3d Admin & Ops — Informe.md
+- docs/Capa 5 — Admin & Operaciones — Addenda Aplicada 2025-09-27.md
+- docs/Capa 1 Identificadores Y Naming — Actualizada (slots Abiertos).md

--- a/plugins/g3d-admin-ops/plugin.php
+++ b/plugins/g3d-admin-ops/plugin.php
@@ -2,7 +2,7 @@
 
 /**
  * Plugin Name: G3D Admin & Ops
- * Description: Esqueleto inicial (sin lógica). Ver docs/ para funciones y contratos.
+ * Description: Esqueleto inicial (sin lógica). Ver docs/Plugin 5 — G3d Admin & Ops — Informe.md.
  * Version: 0.1.0
  * Requires at least: 6.3
  * Requires PHP: 8.2
@@ -11,18 +11,27 @@
  * Text Domain: g3d-admin-ops
  */
 
+declare(strict_types=1);
+
 if (!defined('ABSPATH')) {
     exit;
 }
 
+require_once __DIR__ . '/src/Admin/Menu.php';
+require_once __DIR__ . '/src/Rbac/Capabilities.php';
+require_once __DIR__ . '/src/Audit/Contracts.php';
 
-register_activation_hook(__FILE__, function () {
-    // Placeholder de activación (nop).
-});
-register_deactivation_hook(__FILE__, function () {
-    // Placeholder de desactivación (nop).
+register_activation_hook(__FILE__, static function (): void {
+    // TODO: ver Capa5 §16 (Backups & DR).
 });
 
-add_action('init', function () {
+register_deactivation_hook(__FILE__, static function (): void {
+    // TODO: ver Capa5 §Checklists operativas.
+});
+
+add_action('plugins_loaded', static function (): void {
     load_plugin_textdomain('g3d-admin-ops', false, dirname(plugin_basename(__FILE__)) . '/languages');
 });
+
+$adminOpsMenu = new \G3D\AdminOps\Admin\Menu();
+$adminOpsMenu->register();

--- a/plugins/g3d-admin-ops/src/Admin/Menu.php
+++ b/plugins/g3d-admin-ops/src/Admin/Menu.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\AdminOps\Admin;
+
+final class Menu
+{
+    private const ROOT_SLUG = 'g3d-admin-ops';
+
+    /** @var array<string, array{page_title:string, menu_title:string, capability:string, doc:string}> */
+    private const SECTIONS = [
+        'modelos-glb' => [
+            'page_title' => 'Modelos (GLB)',
+            'menu_title' => 'Modelos (GLB)',
+            'capability' => 'manage_options',
+            'doc' => 'Capa5 §3.1',
+        ],
+        'materiales' => [
+            'page_title' => 'Materiales',
+            'menu_title' => 'Materiales',
+            'capability' => 'manage_options',
+            'doc' => 'Capa5 §3.2',
+        ],
+        'colores' => [
+            'page_title' => 'Colores',
+            'menu_title' => 'Colores',
+            'capability' => 'manage_options',
+            'doc' => 'Capa5 §3.3',
+        ],
+        'texturas' => [
+            'page_title' => 'Texturas',
+            'menu_title' => 'Texturas',
+            'capability' => 'manage_options',
+            'doc' => 'Capa5 §3.4',
+        ],
+        'acabados' => [
+            'page_title' => 'Acabados',
+            'menu_title' => 'Acabados',
+            'capability' => 'manage_options',
+            'doc' => 'Capa5 §3.5',
+        ],
+        'reglas' => [
+            'page_title' => 'Reglas',
+            'menu_title' => 'Reglas',
+            'capability' => 'manage_options',
+            'doc' => 'Capa5 §3.6',
+        ],
+        'i18n' => [
+            'page_title' => 'i18n',
+            'menu_title' => 'i18n',
+            'capability' => 'manage_options',
+            'doc' => 'Capa5 §3.7',
+        ],
+        'previsualizacion' => [
+            'page_title' => 'Previsualización',
+            'menu_title' => 'Previsualización',
+            'capability' => 'manage_options',
+            'doc' => 'Capa5 §3.8',
+        ],
+        'publicacion' => [
+            'page_title' => 'Publicación',
+            'menu_title' => 'Publicación',
+            'capability' => 'manage_options',
+            'doc' => 'Capa5 §3.9',
+        ],
+        'versiones-auditoria' => [
+            'page_title' => 'Versiones & Auditoría',
+            'menu_title' => 'Versiones & Auditoría',
+            'capability' => 'manage_options',
+            'doc' => 'Capa5 §3.10',
+        ],
+        'configuracion' => [
+            'page_title' => 'Configuración',
+            'menu_title' => 'Configuración',
+            'capability' => 'manage_options',
+            'doc' => 'Capa5 §3.11',
+        ],
+        'slots' => [
+            'page_title' => 'Slots (mapeo editorial)',
+            'menu_title' => 'Slots',
+            'capability' => 'manage_options',
+            'doc' => 'Capa5 §3.12',
+        ],
+        'parejas-patillas' => [
+            'page_title' => 'Parejas de Patillas',
+            'menu_title' => 'Parejas L/R',
+            'capability' => 'manage_options',
+            'doc' => 'Capa5 §Addenda 2025-09-27',
+        ],
+    ];
+
+    public function register(): void
+    {
+        add_action('admin_menu', [$this, 'registerMenu'], 20);
+    }
+
+    public function registerMenu(): void
+    {
+        add_menu_page(
+            __('G3D Admin & Ops', 'g3d-admin-ops'),
+            __('G3D Admin & Ops', 'g3d-admin-ops'),
+            'manage_options',
+            self::ROOT_SLUG,
+            [$this, 'renderRoot']
+        );
+
+        foreach (self::SECTIONS as $slug => $section) {
+            add_submenu_page(
+                self::ROOT_SLUG,
+                $section['page_title'],
+                $section['menu_title'],
+                $section['capability'],
+                self::ROOT_SLUG . '-' . $slug,
+                function () use ($section): void {
+                    $this->renderPlaceholder($section['page_title'], $section['doc']);
+                }
+            );
+        }
+    }
+
+    public function renderRoot(): void
+    {
+        $this->renderPlaceholder('G3D Admin & Ops', 'Plugin5 §5');
+    }
+
+    private function renderPlaceholder(string $title, string $docSection): void
+    {
+        echo '<div class="wrap">';
+        printf('<h1>%s</h1>', esc_html($title));
+        printf(
+            '<p>%s</p>',
+            esc_html(
+                sprintf(
+                    /* translators: %s is the documentation reference. */
+                    __('TODO: ver %s', 'g3d-admin-ops'),
+                    $docSection
+                )
+            )
+        );
+        echo '</div>';
+    }
+}

--- a/plugins/g3d-admin-ops/src/Audit/EditorialActionLogger.php
+++ b/plugins/g3d-admin-ops/src/Audit/EditorialActionLogger.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\AdminOps\Audit;
+
+interface EditorialActionLogger
+{
+    /**
+     * TODO: ver Capa5 §Auditoría y logs.
+     */
+    public function logAction(string $actorId, string $action, array $context = []): void;
+}

--- a/plugins/g3d-admin-ops/src/Audit/PairingConsistencyChecker.php
+++ b/plugins/g3d-admin-ops/src/Audit/PairingConsistencyChecker.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\AdminOps\Audit;
+
+interface PairingConsistencyChecker
+{
+    /**
+     * TODO: ver Capa5 §Addenda 2025-09-27.
+     */
+    public function verifyPair(string $pairId, string $leftModelId, string $rightModelId): void;
+}

--- a/plugins/g3d-admin-ops/src/Audit/PublicationAuditTrail.php
+++ b/plugins/g3d-admin-ops/src/Audit/PublicationAuditTrail.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\AdminOps\Audit;
+
+interface PublicationAuditTrail
+{
+    /**
+     * TODO: ver Capa5 §Versionado y publicación.
+     */
+    public function snapshotPublished(string $snapshotId, string $versionId): void;
+
+    /**
+     * TODO: ver Capa5 §Versionado y publicación.
+     */
+    public function rollbackTriggered(string $versionId): void;
+}

--- a/plugins/g3d-admin-ops/src/Audit/ValidatorLogWriter.php
+++ b/plugins/g3d-admin-ops/src/Audit/ValidatorLogWriter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\AdminOps\Audit;
+
+interface ValidatorLogWriter
+{
+    /**
+     * TODO: ver Capa5 §Validadores.
+     */
+    public function storeValidatorRun(string $snapshotId, array $results): void;
+}

--- a/plugins/g3d-admin-ops/src/Audit/WorkflowTransitionLogger.php
+++ b/plugins/g3d-admin-ops/src/Audit/WorkflowTransitionLogger.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\AdminOps\Audit;
+
+interface WorkflowTransitionLogger
+{
+    /**
+     * TODO: ver Capa5 §Estados y flujo de trabajo editorial.
+     */
+    public function logTransition(string $fromState, string $toState, array $diff): void;
+}

--- a/plugins/g3d-admin-ops/src/Rbac/Capabilities.php
+++ b/plugins/g3d-admin-ops/src/Rbac/Capabilities.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\AdminOps\Rbac;
+
+final class Capabilities
+{
+    public const ROLE_EDITOR = 'Editor';
+    public const ROLE_QA_REVISOR = 'QA/Revisor';
+    public const ROLE_PUBLICADOR = 'Publicador';
+    public const ROLE_ADMIN = 'Admin';
+
+    public const WORKFLOW_BORRADOR = 'Borrador';
+    public const WORKFLOW_EN_REVISION = 'En revisión';
+    public const WORKFLOW_APROBADO_QA = 'Aprobado QA';
+    public const WORKFLOW_STAGING = 'Staging';
+    public const WORKFLOW_PUBLICADO = 'Publicado';
+
+    public const PAIR_SYNC_CONTROLS_DEFAULT = [
+        'material',
+        'color',
+        'textura',
+    ];
+
+    public const PAIR_UNSYNCED_CONTROLS_DEFAULT = [
+        'acabado',
+    ];
+}


### PR DESCRIPTION
## Summary
- split each Audit contract interface into its own dedicated file under src/Audit
- remove the legacy Contracts.php aggregator to comply with PSR-12

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da1dba93548323ac38625a14df11d2