### PR TITLE
fix(p1): AdminUI renders validation errors from result.validation (phpstan clean)

### DIFF
--- a/plugins/g3d-models-manager/admin/AdminUI.php
+++ b/plugins/g3d-models-manager/admin/AdminUI.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace G3D\ModelsManager\Admin;
 
 use G3D\ModelsManager\Service\GlbIngestionService;
-use G3D\ModelsManager\Validation\GlbValidationError;
 
 final class AdminUI
 {
@@ -36,8 +35,17 @@ final class AdminUI
             $result = $this->service->ingest($_FILES['g3d_glb_file']);
         }
 
-        $binding = $result['binding'] ?? [];
-        $errors = $result['errors'] ?? [];
+        $binding = [];
+        $validationErrors = [];
+
+        if ($result !== null) {
+            $binding = $result['binding'];
+
+            $validation = $result['validation'];
+            foreach ($validation['errors'] as $rawError) {
+                $validationErrors[] = sprintf('%s: %s', $rawError['code'], $rawError['message']);
+            }
+        }
 
         $slotsValue = '';
         if (!empty($binding['slots_detectados']) && is_array($binding['slots_detectados'])) {
@@ -84,14 +92,12 @@ final class AdminUI
         ?>
         <div class="wrap">
             <h1>Ingesta GLB</h1>
-            <?php if (!empty($errors)) : ?>
+            <?php if (!empty($validationErrors)) : ?>
                 <div class="notice notice-error">
                     <p><strong>Errores</strong></p>
                     <ul>
-                        <?php foreach ($errors as $error) : ?>
-                            <?php if ($error instanceof GlbValidationError) : ?>
-                                <li><?php echo esc_html($error->getCode() . ': ' . $error->getMessage()); ?></li>
-                            <?php endif; ?>
+                        <?php foreach ($validationErrors as $error) : ?>
+                            <li><?php echo esc_html($error); ?></li>
                         <?php endforeach; ?>
                     </ul>
                 </div>

--- a/plugins/g3d-models-manager/src/Service/GlbIngestionService.php
+++ b/plugins/g3d-models-manager/src/Service/GlbIngestionService.php
@@ -19,7 +19,13 @@ final class GlbIngestionService
     /**
      * @param array<string, mixed> $file
      * @param array<string, mixed> $options
-     * @return array{binding: array<string, mixed>, errors: GlbValidationError[]}
+     * @return array{
+     *     binding: array<string, mixed>,
+     *     validation: array{
+     *         is_valid: bool,
+     *         errors: list<array{code: string, message: string}>
+     *     }
+     * }
      */
     public function ingest(array $file, array $options = []): array
     {
@@ -39,9 +45,20 @@ final class GlbIngestionService
 
         $errors = $this->validator->validate($metadata);
 
+        $validationErrors = [];
+        foreach ($errors as $error) {
+            $validationErrors[] = [
+                'code' => $error->getCode(),
+                'message' => $error->getMessage(),
+            ];
+        }
+
         return [
             'binding' => $metadata,
-            'errors' => $errors,
+            'validation' => [
+                'is_valid' => $validationErrors === [],
+                'errors' => $validationErrors,
+            ],
         ];
     }
 


### PR DESCRIPTION
## Summary
- render AdminUI validation messages from the ingestion result's validation payload
- return structured validation metadata from GlbIngestionService so the UI can consume it

## Testing
- composer phpstan

------
https://chatgpt.com/codex/tasks/task_e_68daa5036fac8323baef7ebec4f41f06