### PR TITLE
feat(p1): deterministic GLB ingestion stub (no binaries) + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ dist/
 coverage/
 .cache/
 
+# 3D binaries
+*.glb
+*.gltf
+*.bin
+
 # Env / secrets (no subir)
 .env
 .env.*

--- a/plugins/g3d-models-manager/admin/AdminUI.php
+++ b/plugins/g3d-models-manager/admin/AdminUI.php
@@ -6,6 +6,9 @@ namespace G3D\ModelsManager\Admin;
 
 use G3D\ModelsManager\Service\GlbIngestionService;
 
+/**
+ * @phpstan-import-type IngestionResult from \G3D\ModelsManager\Service\GlbIngestionService
+ */
 final class AdminUI
 {
     private GlbIngestionService $service;
@@ -30,6 +33,7 @@ final class AdminUI
 
     public function renderIngestionPage(): void
     {
+        /** @var IngestionResult|null $result */
         $result = null;
 
         if (
@@ -45,12 +49,8 @@ final class AdminUI
         /** @var list<string> $errors */
         $errors = [];
 
-        if (is_array($result)) {
-            // Aquí PHPStan sabe que existen estas claves en $result.
-            /** @var array<string,mixed> $binding */
+        if ($result !== null) {
             $binding = $result['binding'];
-
-            /** @var array{missing:string[], type: array<int, array{field:string, expected:string}>, ok:bool} $validation */
             $validation = $result['validation'];
 
             if ($validation['missing'] !== []) {

--- a/plugins/g3d-models-manager/admin/AdminUI.php
+++ b/plugins/g3d-models-manager/admin/AdminUI.php
@@ -44,13 +44,13 @@ final class AdminUI
             $result = $this->service->ingest($_FILES['g3d_glb_file']);
         }
 
-        // Valores por defecto cuando no se ha enviado nada todavía.
+        /** @var array<string,mixed> $binding */
         $binding = [];
         /** @var list<string> $errors */
         $errors = [];
 
         if ($result !== null) {
-            $binding = $result['binding'];
+            $binding    = $result['binding'];
             $validation = $result['validation'];
 
             if ($validation['missing'] !== []) {
@@ -66,47 +66,44 @@ final class AdminUI
             }
         }
 
-        $slotsValue = '';
-        if (!empty($binding['slots_detectados']) && is_array($binding['slots_detectados'])) {
-            $slotsValue = implode("\n", array_map('strval', $binding['slots_detectados']));
-        }
+        // ------- Derivados seguros para UI (sin checks redundantes) -------
 
-        $anchorsValue = '';
-        if (!empty($binding['anchors_present']) && is_array($binding['anchors_present'])) {
-            $anchorsValue = implode("\n", array_map('strval', $binding['anchors_present']));
-        }
+        /** @var list<string> $slots */
+        $slots = (array) ($binding['slots_detectados'] ?? []);
+        $slotsValue = $slots === [] ? '' : implode("\n", array_map('strval', $slots));
 
-        $propsValue = '';
-        if (!empty($binding['props']) && is_array($binding['props'])) {
-            $lines = [];
-            foreach ($binding['props'] as $key => $value) {
-                $lines[] = sprintf('%s=%s', (string) $key, (string) $value);
-            }
-            $propsValue = implode("\n", $lines);
-        }
+        /** @var list<string> $anchors */
+        $anchors = (array) ($binding['anchors_present'] ?? []);
+        $anchorsValue = $anchors === [] ? '' : implode("\n", array_map('strval', $anchors));
 
+        /** @var array<string,scalar|array|null> $propsArr */
+        $propsArr = (array) ($binding['props'] ?? []);
+        $propLines = [];
+        foreach ($propsArr as $key => $value) {
+            $propLines[] = sprintf('%s=%s', (string) $key, (string) $value);
+        }
+        $propsValue = $propLines === [] ? '' : implode("\n", $propLines);
+
+        $objName  = isset($binding['object_name']) ? (string) $binding['object_name'] : '';
+        $pattern  = isset($binding['object_name_pattern']) ? (string) $binding['object_name_pattern'] : '';
+        $modelCode = isset($binding['model_code']) ? (string) $binding['model_code'] : '';
+
+        $hasObjectBinding = ($objName !== '' || $pattern !== '' || $modelCode !== '');
         $objectValue = '';
-        $hasObjectBinding = (
-            !empty($binding['object_name'])
-            || !empty($binding['object_name_pattern'])
-            || !empty($binding['model_code'])
-        );
         if ($hasObjectBinding) {
-            $objectValue = (string) ($binding['object_name'] ?? '');
-            if (!empty($binding['object_name_pattern'])) {
-                $objectValue .= $objectValue !== '' ? "\n" : '';
-                $objectValue .= (string) $binding['object_name_pattern'];
+            $objectValue = $objName;
+            if ($pattern !== '') {
+                $objectValue .= ($objectValue !== '' ? "\n" : '') . $pattern;
             }
-            if (!empty($binding['model_code'])) {
-                $objectValue .= $objectValue !== '' ? "\n" : '';
-                $objectValue .= (string) $binding['model_code'];
+            if ($modelCode !== '') {
+                $objectValue .= ($objectValue !== '' ? "\n" : '') . $modelCode;
             }
         }
 
-        $hash = isset($binding['file_hash']) ? (string) $binding['file_hash'] : '';
-        $size = isset($binding['filesize_bytes']) ? (string) $binding['filesize_bytes'] : '';
-        $draco = isset($binding['draco_enabled']) ? (string) $binding['draco_enabled'] : '';
-        $bounding = isset($binding['bounding_box'])
+        $hash     = isset($binding['file_hash']) ? (string) $binding['file_hash'] : '';
+        $size     = isset($binding['filesize_bytes']) ? (string) $binding['filesize_bytes'] : '';
+        $draco    = isset($binding['draco_enabled']) ? (string) $binding['draco_enabled'] : '';
+        $bounding = is_array($binding['bounding_box'] ?? null)
             ? json_encode($binding['bounding_box'], JSON_PRETTY_PRINT)
             : '';
 

--- a/plugins/g3d-models-manager/src/Service/GlbIngestionService.php
+++ b/plugins/g3d-models-manager/src/Service/GlbIngestionService.php
@@ -4,59 +4,258 @@ declare(strict_types=1);
 
 namespace G3D\ModelsManager\Service;
 
+/**
+ * @phpstan-type IngestionProps array{
+ *     socket_width_mm: float,
+ *     socket_height_mm: float,
+ *     variant: 'R'|'U',
+ *     mount_type: 'FRAMED'|'RIMLESS',
+ *     tol_w_mm: float,
+ *     tol_h_mm: float
+ * }
+ * @phpstan-type IngestionBoundingBox array{
+ *     min: array{0: float, 1: float, 2: float},
+ *     max: array{0: float, 1: float, 2: float}
+ * }
+ * @phpstan-type IngestionBinding array{
+ *     file_hash: string,
+ *     filesize_bytes: int,
+ *     draco_enabled: bool,
+ *     bounding_box: IngestionBoundingBox,
+ *     piece_type: 'FRAME',
+ *     object_name: string,
+ *     object_name_pattern: string,
+ *     model_code: string,
+ *     props: IngestionProps,
+ *     anchors_present: list<string>,
+ *     slots_detectados: list<string>,
+ *     scale_unit: string,
+ *     scale_meters_per_unit: float,
+ *     up_axis: string,
+ *     pivot_at_origin: bool
+ * }
+ * @phpstan-type IngestionValidation array{
+ *     missing: list<string>,
+ *     type: list<array{field:string, expected:string}>,
+ *     ok: bool
+ * }
+ * @phpstan-type IngestionResult array{
+ *     binding: IngestionBinding,
+ *     validation: IngestionValidation
+ * }
+ */
 final class GlbIngestionService
 {
     /**
-     * @param array{tmp_name:string,name?:string,size?:int,type?:string,error?:int} $uploaded
-     * @return array{
-     *   binding: array<string,mixed>,
-     *   validation: array{
-     *     missing: string[],
-     *     type: array<int, array{field:string, expected:string}>,
-     *     ok: bool
-     *   }
-     * }
+     * @param array{name:string,tmp_name:string,size:int,type?:string,error?:int} $uploaded
+     * @return array{binding: array<string, mixed>, validation: array<string, mixed>}
+     * @phpstan-return IngestionResult
      */
     public function ingest(array $uploaded): array
     {
-        $binding = [
-            'file_hash' => '',
-            'filesize_bytes' => 0,
-            'draco_enabled' => false,
-            'bounding_box' => null,
-            'slots_detectados' => [],
-            'anchors_present' => [],
-            'props' => [],
-            'object_name' => null,
-            'object_name_pattern' => null,
-            'model_code' => null,
-        ];
-
         $validation = [
             'missing' => [],
             'type' => [],
             'ok' => true,
         ];
 
-        // Validación mínima del "upload".
         if (!is_file($uploaded['tmp_name'])) {
             $validation['missing'][] = 'g3d_glb_file';
             $validation['ok'] = false;
 
             return [
-                'binding' => $binding,
+                'binding' => $this->emptyBinding(),
                 'validation' => $validation,
             ];
         }
 
-        // Metadatos básicos
-        $binding['filesize_bytes'] = (int) (filesize($uploaded['tmp_name']) ?: 0);
-        $hash = @hash_file('sha256', $uploaded['tmp_name']);
-        $binding['file_hash'] = is_string($hash) ? $hash : '';
+        $bytes = file_get_contents($uploaded['tmp_name']);
+        if ($bytes === false) {
+            $bytes = '';
+        }
+
+        $hash = hash('sha256', $bytes);
+        $size = strlen($bytes);
+        $baseName = pathinfo($uploaded['name'], PATHINFO_FILENAME);
+        if ($baseName === '') {
+            $baseName = 'model';
+        }
+
+        $binding = [
+            'file_hash' => $hash,
+            'filesize_bytes' => $size,
+            'draco_enabled' => $this->isDracoEnabled($hash),
+            'bounding_box' => $this->buildBoundingBox($hash),
+            'piece_type' => 'FRAME',
+            'object_name' => $this->buildObjectName($baseName),
+            'object_name_pattern' => $this->buildObjectNamePattern($baseName),
+            'model_code' => $this->buildModelCode($baseName, $hash),
+            'props' => $this->buildProps($hash),
+            'anchors_present' => $this->buildAnchors($hash),
+            'slots_detectados' => $this->buildSlots($hash),
+            'scale_unit' => 'METER',
+            'scale_meters_per_unit' => $this->buildScale($hash),
+            'up_axis' => 'Z',
+            'pivot_at_origin' => $this->isPivotAtOrigin($hash),
+        ];
 
         return [
             'binding' => $binding,
             'validation' => $validation,
         ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     * @phpstan-return IngestionBinding
+     */
+    private function emptyBinding(): array
+    {
+        return [
+            'file_hash' => '',
+            'filesize_bytes' => 0,
+            'draco_enabled' => false,
+            'bounding_box' => [
+                'min' => [0.0, 0.0, 0.0],
+                'max' => [0.0, 0.0, 0.0],
+            ],
+            'piece_type' => 'FRAME',
+            'object_name' => '',
+            'object_name_pattern' => '',
+            'model_code' => '',
+            'props' => [
+                'socket_width_mm' => 0.0,
+                'socket_height_mm' => 0.0,
+                'variant' => 'R',
+                'mount_type' => 'FRAMED',
+                'tol_w_mm' => 0.0,
+                'tol_h_mm' => 0.0,
+            ],
+            'anchors_present' => [],
+            'slots_detectados' => [],
+            'scale_unit' => 'METER',
+            'scale_meters_per_unit' => 1.0,
+            'up_axis' => 'Z',
+            'pivot_at_origin' => true,
+        ];
+    }
+
+    private function isDracoEnabled(string $hash): bool
+    {
+        return (hexdec($this->getHexSegment($hash, 0, 2)) % 2) === 0;
+    }
+
+    /**
+     * @return array{min: array{0: float, 1: float, 2: float}, max: array{0: float, 1: float, 2: float}}
+     * @phpstan-return IngestionBoundingBox
+     */
+    private function buildBoundingBox(string $hash): array
+    {
+        $extentX = $this->normalizeHexToRange($this->getHexSegment($hash, 2, 6), 0.1, 1.5);
+        $extentY = $this->normalizeHexToRange($this->getHexSegment($hash, 8, 6), 0.1, 1.5);
+        $extentZ = $this->normalizeHexToRange($this->getHexSegment($hash, 14, 6), 0.1, 1.5);
+
+        return [
+            'min' => [
+                -$extentX,
+                -$extentY,
+                -$extentZ,
+            ],
+            'max' => [
+                $extentX,
+                $extentY,
+                $extentZ,
+            ],
+        ];
+    }
+
+    private function buildObjectName(string $baseName): string
+    {
+        return $baseName . '_FRAME';
+    }
+
+    private function buildObjectNamePattern(string $baseName): string
+    {
+        return strtoupper($baseName) . '_*';
+    }
+
+    private function buildModelCode(string $baseName, string $hash): string
+    {
+        $suffix = strtoupper(substr($hash, 0, 6));
+
+        return strtoupper($baseName) . '-' . $suffix;
+    }
+
+    /**
+     * @return array<string, float|string>
+     * @phpstan-return IngestionProps
+     */
+    private function buildProps(string $hash): array
+    {
+        return [
+            'socket_width_mm' => $this->normalizeHexToRange($this->getHexSegment($hash, 20, 6), 40.0, 70.0),
+            'socket_height_mm' => $this->normalizeHexToRange($this->getHexSegment($hash, 26, 6), 25.0, 60.0),
+            'variant' => (hexdec($this->getHexSegment($hash, 32, 2)) % 2) === 0 ? 'R' : 'U',
+            'mount_type' => 'FRAMED',
+            'tol_w_mm' => $this->normalizeHexToRange($this->getHexSegment($hash, 34, 4), 0.05, 0.5),
+            'tol_h_mm' => $this->normalizeHexToRange($this->getHexSegment($hash, 38, 4), 0.05, 0.5),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildAnchors(string $hash): array
+    {
+        $anchors = [];
+        $anchors[] = 'FRAME_ANCHOR_' . strtoupper($this->getHexSegment($hash, 42, 4));
+        $anchors[] = 'TEMPLE_L_ANCHOR_' . strtoupper($this->getHexSegment($hash, 46, 4));
+        $anchors[] = 'TEMPLE_R_ANCHOR_' . strtoupper($this->getHexSegment($hash, 50, 4));
+
+        return $anchors;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildSlots(string $hash): array
+    {
+        $slotBase = strtoupper($this->getHexSegment($hash, 54, 6));
+
+        return [
+            'MAT_' . $slotBase,
+        ];
+    }
+
+    private function buildScale(string $hash): float
+    {
+        return $this->normalizeHexToRange($this->getHexSegment($hash, 60, 4), 0.001, 0.01);
+    }
+
+    private function isPivotAtOrigin(string $hash): bool
+    {
+        return (hexdec($this->getHexSegment($hash, 4, 2)) % 2) === 1;
+    }
+
+    private function normalizeHexToRange(string $hex, float $min, float $max): float
+    {
+        $hex = $hex !== '' ? $hex : '0';
+        $value = hexdec($hex);
+        $maxValue = (16 ** strlen($hex)) - 1;
+
+        $ratio = $value / $maxValue;
+        $normalized = $min + ($max - $min) * $ratio;
+
+        return round($normalized, 6);
+    }
+
+    private function getHexSegment(string $hash, int $offset, int $length): string
+    {
+        $segment = substr($hash, $offset, $length);
+        if ($segment === '') {
+            return '0';
+        }
+
+        return $segment;
     }
 }

--- a/plugins/g3d-models-manager/tests/Service/GlbIngestionServiceTest.php
+++ b/plugins/g3d-models-manager/tests/Service/GlbIngestionServiceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\ModelsManager\Tests\Service;
+
+use G3D\ModelsManager\Service\GlbIngestionService;
+use PHPUnit\Framework\TestCase;
+
+final class GlbIngestionServiceTest extends TestCase
+{
+    public function testIngestReturnsDeterministicBinding(): void
+    {
+        $bytes = str_repeat('G', 1536);
+        $tmp = tempnam(sys_get_temp_dir(), 'glb');
+        if ($tmp === false) {
+            self::fail('Unable to create temporary file for testing.');
+        }
+
+        file_put_contents($tmp, $bytes);
+
+        $uploaded = [
+            'name' => 'dummy.glb',
+            'tmp_name' => $tmp,
+            'size' => strlen($bytes),
+            'type' => 'model/gltf-binary',
+            'error' => 0,
+        ];
+
+        $service = new GlbIngestionService();
+
+        try {
+            $result = $service->ingest($uploaded);
+
+            $this->assertIsArray($result['binding']);
+            $this->assertSame(hash('sha256', $bytes), $result['binding']['file_hash']);
+            $this->assertSame(strlen($bytes), $result['binding']['filesize_bytes']);
+            $this->assertTrue($result['validation']['ok']);
+            $this->assertSame([], $result['validation']['missing']);
+            $this->assertSame([], $result['validation']['type']);
+            $this->assertSame('FRAME', $result['binding']['piece_type']);
+            $this->assertIsArray($result['binding']['anchors_present']);
+            $this->assertIsArray($result['binding']['slots_detectados']);
+            $this->assertNotEmpty($result['binding']['slots_detectados']);
+            $this->assertIsArray($result['binding']['props']);
+            $this->assertArrayHasKey('socket_width_mm', $result['binding']['props']);
+            $this->assertArrayHasKey('socket_height_mm', $result['binding']['props']);
+        } finally {
+            unlink($tmp);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement a deterministic ingestion stub that computes hash/size and synthesises binding metadata based on GLB bytes
- update the admin ingestion UI typing to consume the new structured result and ignore missing uploads gracefully
- add repository-wide ignores for binary GLB assets and cover the service with a runtime-generated fixture test

## Testing
- plugins/g3d-models-manager/vendor/bin/phpunit --configuration plugins/g3d-models-manager/phpunit.xml.dist
- vendor/bin/phpstan analyse plugins/g3d-models-manager/src plugins/g3d-models-manager/tests --memory-limit=1G --no-progress

------
https://chatgpt.com/codex/tasks/task_e_68dae10a144883238165542ffb9a7294