### PR TITLE
chore(p1): secure GLB ingestion endpoint (permission callback + 403 tests)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,6 +2,8 @@ parameters:
   level: 5
   paths:
     - plugins
+  excludePaths:
+    - plugins/*/vendor/*
   scanFiles:
     - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
     - vendor/php-stubs/wordpress-globals/wordpress-globals.php

--- a/plugins/g3d-models-manager/src/Api/IngestionController.php
+++ b/plugins/g3d-models-manager/src/Api/IngestionController.php
@@ -27,13 +27,21 @@ final class IngestionController
                 'methods' => 'POST',
                 'callback' => [$this, 'handle'],
                 // TODO: RBAC real (docs §4). Por ahora, admins.
-                'permission_callback' => static fn() => current_user_can('manage_options'),
+                'permission_callback' => static fn () => current_user_can('manage_options'),
             ]
         );
     }
 
     public function handle(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
+        if (! current_user_can('manage_options')) {
+            return new WP_Error(
+                'rest_forbidden',
+                'Forbidden',
+                ['status' => 403]
+            );
+        }
+
         $tmp = tempnam(sys_get_temp_dir(), 'g3d_glb_');
         if ($tmp === false) {
             return new WP_Error(

--- a/plugins/g3d-models-manager/tests/Api/IngestionRouteTest.php
+++ b/plugins/g3d-models-manager/tests/Api/IngestionRouteTest.php
@@ -7,13 +7,57 @@ namespace G3D\ModelsManager\Tests\Api;
 use G3D\ModelsManager\Api\IngestionController;
 use G3D\ModelsManager\Service\GlbIngestionService;
 use PHPUnit\Framework\TestCase;
+use Test_Env\Perms;
+use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 
 final class IngestionRouteTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Perms::denyAll();
+    }
+
+    public function testHandleReturns403WhenUserLacksCapability(): void
+    {
+        Perms::denyAll();
+
+        $service = new GlbIngestionService();
+        $controller = new IngestionController($service);
+
+        $request = new WP_REST_Request('POST', '/g3d/v1/ingest-glb');
+
+        $response = $controller->handle($request);
+
+        self::assertInstanceOf(WP_Error::class, $response);
+        self::assertSame(403, $response->get_error_data()['status'] ?? null);
+    }
+
+    public function testHandleReturns200WhenAdmin(): void
+    {
+        Perms::allowAll();
+
+        $service = new GlbIngestionService();
+        $controller = new IngestionController($service);
+
+        $request = new WP_REST_Request('POST', '/g3d/v1/ingest-glb');
+
+        $response = $controller->handle($request);
+
+        self::assertInstanceOf(WP_REST_Response::class, $response);
+        self::assertSame(200, $response->get_status());
+
+        $data = $response->get_data();
+        self::assertIsArray($data);
+        self::assertArrayHasKey('binding', $data);
+        self::assertArrayHasKey('validation', $data);
+    }
+
     public function testHandleReturnsBindingAndValidation200(): void
     {
+        Perms::allowAll();
+
         $service = new GlbIngestionService();
         $controller = new IngestionController($service);
 

--- a/plugins/g3d-models-manager/tests/bootstrap.php
+++ b/plugins/g3d-models-manager/tests/bootstrap.php
@@ -2,123 +2,157 @@
 // phpcs:ignoreFile
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+namespace {
+    require __DIR__ . '/../vendor/autoload.php';
 
-if (!function_exists('register_rest_route')) {
-    function register_rest_route(string $namespace, string $route, array $args): void
-    {
-        // No-op stub.
+    if (!function_exists('register_rest_route')) {
+        function register_rest_route(string $namespace, string $route, array $args): void
+        {
+            // No-op stub.
+        }
+    }
+
+    if (!function_exists('current_user_can')) {
+        /**
+         * Test stub. Denies everything unless explicitly enabled.
+         */
+        function current_user_can(string $cap): bool
+        {
+            return \Test_Env\Perms::allows($cap);
+        }
+    }
+
+    if (!class_exists('WP_REST_Request')) {
+        class WP_REST_Request
+        {
+            /** @var array<string, mixed> */
+            private array $params = [];
+
+            /** @var array<string, string> */
+            private array $headers = [];
+
+            private ?string $body = null;
+
+            /**
+             * @param array<string, mixed>|string $arg1
+             * @param ?string                     $route
+             */
+            public function __construct(array|string $arg1 = [], ?string $route = null)
+            {
+                if ($route !== null) {
+                    // No-op: compatibilidad de firma.
+                }
+
+                if (is_array($arg1)) {
+                    $this->params = $arg1;
+                    return;
+                }
+            }
+
+            public function set_header(string $name, string $value): void
+            {
+                $this->headers[strtolower($name)] = $value;
+            }
+
+            public function get_header(string $name): ?string
+            {
+                $key = strtolower($name);
+                return $this->headers[$key] ?? null;
+            }
+
+            public function set_body(?string $body): void
+            {
+                $this->body = $body;
+            }
+
+            public function get_body(): ?string
+            {
+                return $this->body;
+            }
+
+            /**
+             * @return array<string, mixed>
+             */
+            public function get_json_params(): array
+            {
+                $contentType = $this->get_header('content-type') ?? $this->get_header('Content-Type') ?? '';
+
+                if ($this->body !== null && stripos($contentType, 'application/json') !== false) {
+                    $decoded = json_decode($this->body, true);
+                    return is_array($decoded) ? $decoded : [];
+                }
+
+                return $this->params;
+            }
+        }
+    }
+
+    if (!class_exists('WP_REST_Response')) {
+        class WP_REST_Response
+        {
+            public function __construct(private mixed $data = null, private int $status = 200)
+            {
+            }
+
+            public function get_data(): mixed
+            {
+                return $this->data;
+            }
+
+            public function get_status(): int
+            {
+                return $this->status;
+            }
+        }
+    }
+
+    if (!class_exists('WP_Error')) {
+        class WP_Error
+        {
+            /** @param array<string, mixed> $data */
+            public function __construct(private string $code, private string $message, private array $data = [])
+            {
+            }
+
+            public function get_error_code(): string
+            {
+                return $this->code;
+            }
+
+            public function get_error_message(): string
+            {
+                return $this->message;
+            }
+
+            /**
+             * @return array<string, mixed>
+             */
+            public function get_error_data(): array
+            {
+                return $this->data;
+            }
+        }
     }
 }
 
-if (!class_exists('WP_REST_Request')) {
-    class WP_REST_Request
+namespace Test_Env {
+    final class Perms
     {
-        /** @var array<string, mixed> */
-        private array $params = [];
+        private static bool $allowAll = false;
 
-        /** @var array<string, string> */
-        private array $headers = [];
-
-        private ?string $body = null;
-
-        /**
-         * @param array<string, mixed>|string $arg1
-         * @param ?string                     $route
-         */
-        public function __construct(array|string $arg1 = [], ?string $route = null)
+        public static function allows(string $cap): bool
         {
-            if ($route !== null) {
-                // No-op: compatibilidad de firma.
-            }
-
-            if (is_array($arg1)) {
-                $this->params = $arg1;
-                return;
-            }
+            return self::$allowAll;
         }
 
-        public function set_header(string $name, string $value): void
+        public static function allowAll(): void
         {
-            $this->headers[strtolower($name)] = $value;
+            self::$allowAll = true;
         }
 
-        public function get_header(string $name): ?string
+        public static function denyAll(): void
         {
-            $key = strtolower($name);
-            return $this->headers[$key] ?? null;
-        }
-
-        public function set_body(?string $body): void
-        {
-            $this->body = $body;
-        }
-
-        public function get_body(): ?string
-        {
-            return $this->body;
-        }
-
-        /**
-         * @return array<string, mixed>
-         */
-        public function get_json_params(): array
-        {
-            $contentType = $this->get_header('content-type') ?? $this->get_header('Content-Type') ?? '';
-
-            if ($this->body !== null && stripos($contentType, 'application/json') !== false) {
-                $decoded = json_decode($this->body, true);
-                return is_array($decoded) ? $decoded : [];
-            }
-
-            return $this->params;
-        }
-    }
-}
-
-if (!class_exists('WP_REST_Response')) {
-    class WP_REST_Response
-    {
-        public function __construct(private mixed $data = null, private int $status = 200)
-        {
-        }
-
-        public function get_data(): mixed
-        {
-            return $this->data;
-        }
-
-        public function get_status(): int
-        {
-            return $this->status;
-        }
-    }
-}
-
-if (!class_exists('WP_Error')) {
-    class WP_Error
-    {
-        /** @param array<string, mixed> $data */
-        public function __construct(private string $code, private string $message, private array $data = [])
-        {
-        }
-
-        public function get_error_code(): string
-        {
-            return $this->code;
-        }
-
-        public function get_error_message(): string
-        {
-            return $this->message;
-        }
-
-        /**
-         * @return array<string, mixed>
-         */
-        public function get_error_data(): array
-        {
-            return $this->data;
+            self::$allowAll = false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- gate the GLB ingestion route behind the WordPress `manage_options` capability in the controller and handler
- add test-only permission stubs with allow/deny switches for exercising RBAC scenarios
- expand ingestion route tests to cover admin/forbidden responses and keep existing binding checks passing
- exclude plugin vendor directories from PHPStan analysis so composer-installed fixtures don't break the build

## Testing
- plugins/g3d-models-manager/vendor/bin/phpunit -c plugins/g3d-models-manager/phpunit.xml.dist
- vendor/bin/phpstan analyse --memory-limit=1G --no-progress

------
https://chatgpt.com/codex/tasks/task_e_68daf2c51c788323a60045087c92bd13