### PR TITLE
feat(p2): endpoint lectura de reglas de catálogo (stub) + tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,12 @@
         "phpstan/phpstan": "^1.11",
         "php-stubs/wordpress-globals": "^0.2",
         "php-stubs/wordpress-stubs": "^6.4",
-        "phpunit/phpunit": "^11.2"
+        "phpunit/phpunit": "^11.2",
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "scripts": {
-        "phpstan": "vendor/bin/phpstan analyse --memory-limit=512M"
+        "phpcs": "vendor/bin/phpcs --standard=PSR12 plugins/g3d-catalog-rules",
+        "phpstan": "vendor/bin/phpstan analyse --memory-limit=512M",
+        "test": "vendor/bin/phpunit --configuration plugins/g3d-catalog-rules/phpunit.xml.dist"
     }
 }

--- a/plugins/g3d-catalog-rules/plugin.php
+++ b/plugins/g3d-catalog-rules/plugin.php
@@ -13,15 +13,24 @@
 
 declare(strict_types=1);
 
-use G3dCatalogRules\Api\CatalogRulesController;
+use G3D\CatalogRules\Api\RulesReadController;
 
 if (!defined('ABSPATH')) {
     exit;
 }
 
 spl_autoload_register(static function (string $class): void {
-    if (str_starts_with($class, 'G3dCatalogRules\\')) {
-        $relative = substr($class, strlen('G3dCatalogRules\\'));
+    $prefixes = [
+        'G3D\\CatalogRules\\',
+        'G3dCatalogRules\\',
+    ];
+
+    foreach ($prefixes as $prefix) {
+        if (!str_starts_with($class, $prefix)) {
+            continue;
+        }
+
+        $relative = substr($class, strlen($prefix));
         $relativePath = str_replace('\\', '/', $relative);
         $file = __DIR__ . '/src/' . $relativePath . '.php';
 
@@ -36,6 +45,5 @@ add_action('init', static function (): void {
 });
 
 add_action('rest_api_init', static function (): void {
-    $controller = new CatalogRulesController();
-    $controller->registerRoutes();
+    (new RulesReadController())->registerRoutes();
 });

--- a/plugins/g3d-catalog-rules/src/Api/RulesReadController.php
+++ b/plugins/g3d-catalog-rules/src/Api/RulesReadController.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\CatalogRules\Api;
+
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * @phpstan-type SlotControl array{
+ *     type: 'material'|'color'|'textura'|'acabado',
+ *     affects_sku: bool
+ * }
+ * @phpstan-type SlotDefaults array<string, string>
+ * @phpstan-type SlotConfig array{
+ *     controles: list<SlotControl>,
+ *     defaults: SlotDefaults,
+ *     visible: bool,
+ *     order: int
+ * }
+ * @phpstan-type SlotMapping array<string, array<string, SlotConfig>>
+ * @phpstan-type RulesSection array{
+ *     material_to_modelos: array<string, array<string, list<string>>>,
+ *     material_to_colores: array<string, list<string>>,
+ *     material_to_texturas: array<string, list<string>>,
+ *     defaults: array<string, array<string, string>>,
+ *     encaje: array<string, array<string, float>>,
+ *     slot_mapping_editorial: SlotMapping
+ * }
+ * @phpstan-type EntitiesSection array{
+ *     piezas: list<array{id: string, order: int}>,
+ *     modelos: list<array{id: string, g3d_model_id: string, slots_detectados: list<string>}>,
+ *     materiales: list<array{id: string, defaults: array<string, string>}>,
+ *     colores: list<array{id: string, hex: string}>,
+ *     texturas: list<array{
+ *         id: string,
+ *         slot: string,
+ *         defines_color: bool,
+ *         source: string
+ *     }>,
+ *     acabados: list<array{id: string}>
+ * }
+ * @phpstan-type RulesPayload array{
+ *     id: string,
+ *     schema_version: string,
+ *     producto_id: string,
+ *     published_at: string,
+ *     published_by: string,
+ *     notes: string,
+ *     ver: string,
+ *     locales: list<string>,
+ *     sku_policy: array{include_morphs_in_sku: bool},
+ *     entities: EntitiesSection,
+ *     rules: RulesSection
+ * }
+ */
+final class RulesReadController
+{
+    public function registerRoutes(): void
+    {
+        register_rest_route(
+            'g3d/v1',
+            '/catalog/rules',
+            [
+                'methods' => 'GET',
+                'callback' => [$this, 'handle'],
+                'permission_callback' => '__return_true',
+                'args' => [
+                    'producto_id' => [
+                        'required' => true,
+                        'type' => 'string',
+                    ],
+                    'locale' => [
+                        'required' => false,
+                        'type' => 'string',
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return WP_REST_Response|WP_Error
+     */
+    public function handle(WP_REST_Request $request)
+    {
+        $params = $this->getRequestParams($request);
+        $productoId = isset($params['producto_id']) ? (string) $params['producto_id'] : '';
+
+        if ($productoId === '') {
+            return new WP_Error(
+                'g3d_catalog_rules_missing_producto_id',
+                'Missing required query parameter: producto_id.',
+                ['status' => 400]
+            );
+        }
+
+        $locale = isset($params['locale']) ? (string) $params['locale'] : null;
+
+        return new WP_REST_Response(
+            $this->createPayload($productoId, $locale),
+            200
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getRequestParams(WP_REST_Request $request): array
+    {
+        if (method_exists($request, 'get_params')) {
+            /** @var array<string, mixed> $params */
+            $params = $request->get_params();
+
+            return $params;
+        }
+
+        /** @var array<string, mixed> $params */
+        $params = $request->get_json_params();
+
+        return $params;
+    }
+
+    /**
+     * @return RulesPayload
+     */
+    private function createPayload(string $productoId, ?string $locale): array
+    {
+        $localeList = $locale !== null && $locale !== '' ? [$locale] : ['es-ES'];
+
+        return [
+            'id' => 'snap:2025-09-27T18:45:00Z',
+            'schema_version' => '2.0.0',
+            'producto_id' => $productoId,
+            'published_at' => '2025-09-27T18:45:00Z',
+            'published_by' => 'user:admin',
+            'notes' => 'v2 — slots abiertos',
+            'ver' => 'ver:2025-09-27T18:45:00Z',
+            'locales' => $localeList,
+            'sku_policy' => [
+                'include_morphs_in_sku' => false,
+            ],
+            'entities' => [
+                'piezas' => [
+                    [
+                        'id' => 'pieza:frame',
+                        'order' => 1,
+                        /*
+                         * TODO(docs/Capa 2 Schemas Snapshot — Actualizada (slots Abiertos).md §1.2 Pieza)
+                         */
+                    ],
+                    [
+                        'id' => 'pieza:temple',
+                        'order' => 2,
+                        /*
+                         * TODO(docs/Capa 2 Schemas Snapshot — Actualizada (slots Abiertos).md §1.2 Pieza)
+                         */
+                    ],
+                ],
+                'modelos' => [
+                    [
+                        'id' => 'modelo:FR_A_R',
+                        'g3d_model_id' => 'modelo:FR_A_R',
+                        'slots_detectados' => ['MAT_BASE', 'MAT_TIP'],
+                        /*
+                         * TODO(docs/Capa 2 Schemas Snapshot — Actualizada (slots Abiertos).md §1.3 Modelo)
+                         */
+                    ],
+                ],
+                'materiales' => [
+                    [
+                        'id' => 'mat:acetato',
+                        'defaults' => [
+                            'color' => 'col:black',
+                            'textura' => 'tex:acetato_base',
+                        ],
+                        /*
+                         * TODO(docs/Capa 2 Schemas Snapshot — Actualizada (slots Abiertos).md §1.4 Material)
+                         */
+                    ],
+                ],
+                'colores' => [
+                    [
+                        'id' => 'col:black',
+                        'hex' => '#000000',
+                        /*
+                         * TODO(docs/Capa 2 Schemas Snapshot — Actualizada (slots Abiertos).md §1.5 Color)
+                         */
+                    ],
+                ],
+                'texturas' => [
+                    [
+                        'id' => 'tex:acetato_base',
+                        'slot' => 'MAT_BASE',
+                        'defines_color' => true,
+                        'source' => 'embedded',
+                        /*
+                         * TODO(docs/Capa 2 Schemas Snapshot — Actualizada (slots Abiertos).md §1.6 Textura)
+                         */
+                    ],
+                ],
+                'acabados' => [
+                    [
+                        'id' => 'fin:clearcoat_high',
+                        /*
+                         * TODO(docs/Capa 2 Schemas Snapshot — Actualizada (slots Abiertos).md §1.7 Acabado)
+                         */
+                    ],
+                ],
+            ],
+            'rules' => [
+                'material_to_modelos' => [
+                    'pieza:frame' => [
+                        'mat:acetato' => ['modelo:FR_A_R'],
+                    ],
+                ],
+                'material_to_colores' => [
+                    'mat:acetato' => ['col:black', 'col:white'],
+                ],
+                'material_to_texturas' => [
+                    'mat:acetato' => ['tex:acetato_base'],
+                ],
+                'defaults' => [
+                    'mat:acetato' => [
+                        'color' => 'col:black',
+                        'textura' => 'tex:acetato_base',
+                    ],
+                ],
+                'encaje' => [
+                    'clearance_por_material_mm' => [
+                        'mat:acetato' => 0.10,
+                    ],
+                    // TODO(docs/Capa 2 Schemas Snapshot — Actualizada (slots Abiertos).md §Encaje y morphs)
+                ],
+                'slot_mapping_editorial' => [
+                    'pieza:frame' => [
+                        'MAT_BASE' => [
+                            'controles' => [
+                                [
+                                    'type' => 'material',
+                                    'affects_sku' => true,
+                                ],
+                                [
+                                    'type' => 'color',
+                                    'affects_sku' => true,
+                                ],
+                                [
+                                    'type' => 'textura',
+                                    'affects_sku' => true,
+                                ],
+                                [
+                                    'type' => 'acabado',
+                                    'affects_sku' => false,
+                                ],
+                            ],
+                            'defaults' => [
+                                'material' => 'mat:acetato',
+                                'color' => 'col:black',
+                                'textura' => 'tex:acetato_base',
+                                // TODO(docs/Plugin 2 — G3D Catalog Rules — Informe.md §4.4 Slots (mapeo editorial))
+                            ],
+                            'visible' => true,
+                            'order' => 1,
+                        ],
+                    ],
+                ],
+                // TODO(docs/Capa 2 Schemas Snapshot — Actualizada (slots Abiertos).md §Rules: morph_rules)
+            ],
+        ];
+    }
+}

--- a/plugins/g3d-catalog-rules/tests/Api/RulesReadRouteTest.php
+++ b/plugins/g3d-catalog-rules/tests/Api/RulesReadRouteTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\CatalogRules\Tests\Api;
+
+use G3D\CatalogRules\Api\RulesReadController;
+use PHPUnit\Framework\TestCase;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class RulesReadRouteTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['g3d_catalog_rules_registered_routes'] = [];
+    }
+
+    public function testRegisterRoutesRegistersCatalogRulesReadEndpoint(): void
+    {
+        $controller = new RulesReadController();
+        $controller->registerRoutes();
+
+        self::assertNotEmpty($GLOBALS['g3d_catalog_rules_registered_routes']);
+
+        $route = $GLOBALS['g3d_catalog_rules_registered_routes'][0];
+        self::assertSame('g3d/v1', $route['namespace']);
+        self::assertSame('/catalog/rules', $route['route']);
+        self::assertSame('GET', $route['args']['methods']);
+        self::assertSame([$controller, 'handle'], $route['args']['callback']);
+        self::assertSame('__return_true', $route['args']['permission_callback']);
+        self::assertArrayHasKey('producto_id', $route['args']['args']);
+        self::assertTrue($route['args']['args']['producto_id']['required']);
+    }
+
+    public function testHandleReturnsCatalogRulesSnapshotPayload(): void
+    {
+        $controller = new RulesReadController();
+        $request = new WP_REST_Request('GET', '/g3d/v1/catalog/rules');
+        $request->set_header('Content-Type', 'application/json');
+        $request->set_body((string) json_encode([
+            'producto_id' => 'prod:base',
+            'locale' => 'es-ES',
+        ]));
+
+        $response = $controller->handle($request);
+
+        self::assertInstanceOf(WP_REST_Response::class, $response);
+        self::assertSame(200, $response->get_status());
+
+        $data = $response->get_data();
+        self::assertIsArray($data);
+        self::assertSame('prod:base', $data['producto_id'] ?? null);
+        self::assertSame(['es-ES'], $data['locales'] ?? []);
+        self::assertArrayHasKey('rules', $data);
+        self::assertIsArray($data['rules']);
+        self::assertArrayHasKey('material_to_modelos', $data['rules']);
+        self::assertArrayHasKey('slot_mapping_editorial', $data['rules']);
+        self::assertArrayHasKey('entities', $data);
+        self::assertIsArray($data['entities']['piezas'] ?? null);
+    }
+
+    public function testHandleReturnsErrorWhenProductoIdMissing(): void
+    {
+        $controller = new RulesReadController();
+        $request = new WP_REST_Request('GET', '/g3d/v1/catalog/rules');
+
+        $response = $controller->handle($request);
+
+        self::assertInstanceOf(WP_Error::class, $response);
+        self::assertSame('g3d_catalog_rules_missing_producto_id', $response->get_error_code());
+        $errorData = $response->get_error_data();
+        self::assertSame(400, $errorData['status'] ?? null);
+    }
+}

--- a/plugins/g3d-catalog-rules/tests/bootstrap.php
+++ b/plugins/g3d-catalog-rules/tests/bootstrap.php
@@ -4,16 +4,23 @@
 declare(strict_types=1);
 
 spl_autoload_register(static function (string $class): void {
-    if (!str_starts_with($class, 'G3dCatalogRules\\')) {
-        return;
-    }
+    $prefixes = [
+        'G3D\\CatalogRules\\',
+        'G3dCatalogRules\\',
+    ];
 
-    $relative = substr($class, strlen('G3dCatalogRules\\'));
-    $relativePath = str_replace('\\', '/', $relative);
-    $file = __DIR__ . '/../src/' . $relativePath . '.php';
+    foreach ($prefixes as $prefix) {
+        if (!str_starts_with($class, $prefix)) {
+            continue;
+        }
 
-    if (is_file($file)) {
-        require_once $file;
+        $relative = substr($class, strlen($prefix));
+        $relativePath = str_replace('\\', '/', $relative);
+        $file = __DIR__ . '/../src/' . $relativePath . '.php';
+
+        if (is_file($file)) {
+            require_once $file;
+        }
     }
 });
 
@@ -111,6 +118,34 @@ if (!class_exists('WP_REST_Response')) {
         public function get_status(): int
         {
             return $this->status;
+        }
+    }
+}
+
+if (!class_exists('WP_Error')) {
+    class WP_Error
+    {
+        /** @param array<string, mixed> $data */
+        public function __construct(private string $code, private string $message, private array $data = [])
+        {
+        }
+
+        public function get_error_code(): string
+        {
+            return $this->code;
+        }
+
+        public function get_error_message(): string
+        {
+            return $this->message;
+        }
+
+        /**
+         * @return array<string, mixed>
+         */
+        public function get_error_data(): array
+        {
+            return $this->data;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add public read-only catalog rules endpoint stub aligned with published snapshot contract
- register the controller in the plugin bootstrap and extend autoload/test bootstrap for the G3D namespace
- add deterministic snapshot fixture response with validation tests and wire composer scripts for phpcs/phpunit

## Testing
- composer phpcs
- composer phpstan
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68daf756b3088323878e2b5d23530edf