### PR TITLE
feat(p4): base pública del Wizard (shortcode + enqueue + datos)

### DIFF
--- a/plugins/gafas3d-wizard-modal/assets/css/wizard-modal.css
+++ b/plugins/gafas3d-wizard-modal/assets/css/wizard-modal.css
@@ -1,0 +1,2 @@
+/* Stub inicial; TODO(doc §estilos accesibles) */
+.g3d-wizard-modal__overlay[hidden] { display: none; }

--- a/plugins/gafas3d-wizard-modal/assets/js/wizard-modal.js
+++ b/plugins/gafas3d-wizard-modal/assets/js/wizard-modal.js
@@ -1,0 +1,7 @@
+(function () {
+  // Stub inicial: progressive enhancement mínimo y sin lógica.
+  // TODO(doc §5): focus-trap, ARIA updates, navegación de pasos.
+  document.addEventListener('click', function (e) {
+    // placeholder: no-op
+  });
+}());

--- a/plugins/gafas3d-wizard-modal/plugin.php
+++ b/plugins/gafas3d-wizard-modal/plugin.php
@@ -13,7 +13,8 @@
 
 declare(strict_types=1);
 
-use Gafas3d\WizardModal\Front\Assets;
+use Gafas3d\WizardModal\PublicAssets\Assets;
+use Gafas3d\WizardModal\Shortcode\WizardShortcode;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -37,6 +38,7 @@ spl_autoload_register(static function (string $class): void {
 
 add_action('init', static function (): void {
     load_plugin_textdomain('gafas3d-wizard-modal', false, dirname(plugin_basename(__FILE__)) . '/languages');
+    WizardShortcode::register();
 });
 
-Assets::init(__FILE__);
+add_action('wp_enqueue_scripts', [Assets::class, 'register']);

--- a/plugins/gafas3d-wizard-modal/src/PublicAssets/Assets.php
+++ b/plugins/gafas3d-wizard-modal/src/PublicAssets/Assets.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gafas3d\WizardModal\PublicAssets;
+
+use function dirname;
+use function is_admin;
+use function plugins_url;
+use function wp_enqueue_script;
+use function wp_enqueue_style;
+use function wp_localize_script;
+use function wp_register_script;
+use function wp_register_style;
+
+final class Assets
+{
+    private const HANDLE = 'g3d-wizard-modal';
+    private const VERSION = '0.1.0';
+
+    private function __construct()
+    {
+    }
+
+    public static function register(): void
+    {
+        if (is_admin()) {
+            return;
+        }
+
+        $pluginFile = dirname(__DIR__, 2) . '/plugin.php';
+
+        wp_register_style(
+            self::HANDLE,
+            plugins_url('assets/css/wizard-modal.css', $pluginFile),
+            [],
+            self::VERSION
+        );
+
+        wp_register_script(
+            self::HANDLE,
+            plugins_url('assets/js/wizard-modal.js', $pluginFile),
+            [],
+            self::VERSION,
+            true
+        );
+
+        wp_localize_script(
+            self::HANDLE,
+            'G3DWIZ',
+            [
+                'version' => self::VERSION,
+            ]
+        );
+
+        wp_enqueue_style(self::HANDLE);
+        wp_enqueue_script(self::HANDLE);
+    }
+}

--- a/plugins/gafas3d-wizard-modal/src/Shortcode/WizardShortcode.php
+++ b/plugins/gafas3d-wizard-modal/src/Shortcode/WizardShortcode.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gafas3d\WizardModal\Shortcode;
+
+use Gafas3d\WizardModal\UI\Modal;
+
+use function add_shortcode;
+use function esc_attr;
+use function implode;
+use function ob_get_clean;
+use function ob_start;
+use function sprintf;
+use function str_contains;
+
+final class WizardShortcode
+{
+    private const SHORTCODE_TAG = 'g3d_wizard_modal';
+    private const ROOT_ID = 'gafas3d-wizard-modal-root';
+
+    private function __construct()
+    {
+    }
+
+    public static function register(): void
+    {
+        add_shortcode(self::SHORTCODE_TAG, static function (): string {
+            ob_start();
+            Modal::render();
+            $modalHtml = (string) ob_get_clean();
+
+            if (str_contains($modalHtml, 'id="' . self::ROOT_ID . '"')) {
+                return $modalHtml;
+            }
+
+            $attributes = [
+                sprintf('id="%s"', esc_attr(self::ROOT_ID)),
+                sprintf(
+                    'data-g3d-endpoint-rules="%s"',
+                    esc_attr('// TODO(docs/plugin-4-gafas3d-wizard-modal.md §9)')
+                ),
+                sprintf('data-g3d-endpoint-validate="%s"', esc_attr('/validate-sign')),
+            ];
+
+            return sprintf(
+                '<div %s>%s</div>',
+                implode(' ', $attributes),
+                $modalHtml
+            );
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- register the [g3d_wizard_modal] shortcode to render the existing modal markup within a public root container and expose documented data attributes
- enqueue public CSS/JS assets with localized config for the wizard modal frontend
- add stubbed public asset files to serve as the foundation for future progressive enhancement

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dafc514e088323b8d803cb97b86902