### PR TITLE
feat(p0): vendor base helper (cdn route builder, paths, vendor guard) + tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,11 @@
         "squizlabs/php_codesniffer": "^4.0"
     },
     "scripts": {
-        "phpcs": "vendor/bin/phpcs --standard=PSR12 plugins/g3d-catalog-rules",
+        "phpcs": "vendor/bin/phpcs --standard=PSR12 plugins/g3d-catalog-rules plugins/g3d-vendor-base-helper",
         "phpstan": "vendor/bin/phpstan analyse --memory-limit=512M",
-        "test": "vendor/bin/phpunit --configuration plugins/g3d-catalog-rules/phpunit.xml.dist"
+        "test": [
+            "vendor/bin/phpunit --configuration plugins/g3d-catalog-rules/phpunit.xml.dist",
+            "vendor/bin/phpunit --configuration plugins/g3d-vendor-base-helper/phpunit.xml.dist"
+        ]
     }
 }

--- a/plugins/g3d-vendor-base-helper/phpunit.xml.dist
+++ b/plugins/g3d-vendor-base-helper/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         cacheResult="false">
+    <testsuites>
+        <testsuite name="G3D Vendor Base Helper">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/plugins/g3d-vendor-base-helper/plugin.php
+++ b/plugins/g3d-vendor-base-helper/plugin.php
@@ -17,6 +17,28 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+spl_autoload_register(static function (string $class): void {
+    if (!str_starts_with($class, 'G3D\\VendorBase\\')) {
+        return;
+    }
+
+    $relative = substr($class, strlen('G3D\\VendorBase\\'));
+    $relativePath = str_replace('\\', '/', $relative);
+    $file = __DIR__ . '/src/' . $relativePath . '.php';
+
+    if (is_file($file)) {
+        require_once $file;
+    }
+});
+
 add_action('init', static function (): void {
     load_plugin_textdomain('g3d-vendor-base-helper', false, dirname(plugin_basename(__FILE__)) . '/languages');
+});
+
+register_activation_hook(__FILE__, static function (): void {
+    \G3D\VendorBase\Security\VendorGuard::assertReady();
+});
+
+register_deactivation_hook(__FILE__, static function (): void {
+    // No-op: placeholder para simetría.
 });

--- a/plugins/g3d-vendor-base-helper/src/Cdn/RouteBuilder.php
+++ b/plugins/g3d-vendor-base-helper/src/Cdn/RouteBuilder.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Cdn;
+
+final class RouteBuilder
+{
+    /**
+     * Construye una URL CDN base + path normalizado.
+     *
+     * @param string $cdnBase e.g. https://cdn.example
+     * @param string $path    e.g. /assets/img/foo.png o assets/img/foo.png
+     */
+    public static function build(string $cdnBase, string $path): string
+    {
+        $base = rtrim($cdnBase, '/');
+        $normalizedPath = '/' . ltrim($path, '/');
+
+        return $base . $normalizedPath;
+    }
+}

--- a/plugins/g3d-vendor-base-helper/src/Paths/PluginPaths.php
+++ b/plugins/g3d-vendor-base-helper/src/Paths/PluginPaths.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Paths;
+
+final class PluginPaths
+{
+    /**
+     * Devuelve ruta absoluta segura a subruta del plugin.
+     *
+     * @param string $pluginFile plugin.php (__FILE__ del plugin)
+     * @param string $relative   subruta relativa (sin ..)
+     */
+    public static function resolve(string $pluginFile, string $relative): string
+    {
+        $normalizedPluginFile = \str_replace('\\', '/', $pluginFile);
+        $base = \dirname($normalizedPluginFile);
+        $base = $base === '.' ? '' : $base;
+        $base = \str_replace('\\', '/', $base);
+        $normalized = \str_replace(['..', '\\'], ['', '/'], $relative);
+        $normalized = (string) \preg_replace('#/+#', '/', $normalized);
+
+        return $base . '/' . ltrim($normalized, '/');
+    }
+}

--- a/plugins/g3d-vendor-base-helper/src/Security/VendorGuard.php
+++ b/plugins/g3d-vendor-base-helper/src/Security/VendorGuard.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Security;
+
+use RuntimeException;
+
+final class VendorGuard
+{
+    /**
+     * Verifica precondiciones mínimas del runtime.
+     * Lanza RuntimeException con mensaje claro si falla.
+     *
+     * TODO(doc §requisitos): ampliar checks (extensiones, versiones).
+     */
+    public static function assertReady(): void
+    {
+        if (!\function_exists('json_encode')) {
+            throw new RuntimeException('json extension requerida');
+        }
+
+        if (\PHP_VERSION_ID < 80200) {
+            throw new RuntimeException('PHP >= 8.2 requerido');
+        }
+    }
+}

--- a/plugins/g3d-vendor-base-helper/tests/Cdn/RouteBuilderTest.php
+++ b/plugins/g3d-vendor-base-helper/tests/Cdn/RouteBuilderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Tests\Cdn;
+
+use G3D\VendorBase\Cdn\RouteBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class RouteBuilderTest extends TestCase
+{
+    public function testBuildNormalizesBaseAndPath(): void
+    {
+        $url = RouteBuilder::build('https://cdn.example', 'assets/img/logo.png');
+
+        self::assertSame('https://cdn.example/assets/img/logo.png', $url);
+    }
+
+    public function testBuildTrimsBaseTrailingSlash(): void
+    {
+        $url = RouteBuilder::build('https://cdn.example/', 'assets/img/logo.png');
+
+        self::assertSame('https://cdn.example/assets/img/logo.png', $url);
+    }
+
+    public function testBuildEnsuresLeadingSlashOnPath(): void
+    {
+        $url = RouteBuilder::build('https://cdn.example', '/assets/img/logo.png');
+
+        self::assertSame('https://cdn.example/assets/img/logo.png', $url);
+    }
+
+    public function testBuildHandlesBothBaseTrailingAndPathLeadingSlash(): void
+    {
+        $url = RouteBuilder::build('https://cdn.example/', '/assets/img/logo.png');
+
+        self::assertSame('https://cdn.example/assets/img/logo.png', $url);
+    }
+}

--- a/plugins/g3d-vendor-base-helper/tests/Paths/PluginPathsTest.php
+++ b/plugins/g3d-vendor-base-helper/tests/Paths/PluginPathsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Tests\Paths;
+
+use G3D\VendorBase\Paths\PluginPaths;
+use PHPUnit\Framework\TestCase;
+
+final class PluginPathsTest extends TestCase
+{
+    public function testResolveJoinsBaseAndRelativePath(): void
+    {
+        $pluginFile = '/var/www/html/wp-content/plugins/g3d-vendor-base-helper/plugin.php';
+        $resolved = PluginPaths::resolve($pluginFile, 'assets/js/app.js');
+
+        self::assertSame(
+            '/var/www/html/wp-content/plugins/g3d-vendor-base-helper/assets/js/app.js',
+            $resolved
+        );
+    }
+
+    public function testResolveNormalizesDirectoryTraversal(): void
+    {
+        $pluginFile = '/var/www/html/wp-content/plugins/g3d-vendor-base-helper/plugin.php';
+        $resolved = PluginPaths::resolve($pluginFile, '../assets/../css/../js/app.js');
+
+        self::assertSame(
+            '/var/www/html/wp-content/plugins/g3d-vendor-base-helper/assets/css/js/app.js',
+            $resolved
+        );
+    }
+
+    public function testResolveReplacesBackslashes(): void
+    {
+        $pluginFile = 'C:\\wordpress\\wp-content\\plugins\\g3d-vendor-base-helper\\plugin.php';
+        $resolved = PluginPaths::resolve($pluginFile, 'assets\\img\\logo.png');
+
+        self::assertSame(
+            'C:/wordpress/wp-content/plugins/g3d-vendor-base-helper/assets/img/logo.png',
+            $resolved
+        );
+    }
+}

--- a/plugins/g3d-vendor-base-helper/tests/Security/VendorGuardTest.php
+++ b/plugins/g3d-vendor-base-helper/tests/Security/VendorGuardTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Tests\Security;
+
+use G3D\VendorBase\Security\VendorGuard;
+use PHPUnit\Framework\TestCase;
+
+final class VendorGuardTest extends TestCase
+{
+    public function testAssertReadyPassesInSupportedEnvironment(): void
+    {
+        VendorGuard::assertReady();
+
+        self::assertTrue(true);
+    }
+}

--- a/plugins/g3d-vendor-base-helper/tests/bootstrap.php
+++ b/plugins/g3d-vendor-base-helper/tests/bootstrap.php
@@ -1,0 +1,56 @@
+<?php
+// phpcs:ignoreFile
+
+declare(strict_types=1);
+
+spl_autoload_register(static function (string $class): void {
+    if (!str_starts_with($class, 'G3D\\VendorBase\\')) {
+        return;
+    }
+
+    $relative = substr($class, strlen('G3D\\VendorBase\\'));
+    $relativePath = str_replace('\\', '/', $relative);
+    $file = __DIR__ . '/../src/' . $relativePath . '.php';
+
+    if (is_file($file)) {
+        require_once $file;
+    }
+});
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__);
+}
+
+if (!function_exists('plugin_basename')) {
+    function plugin_basename(string $file): string
+    {
+        return basename($file);
+    }
+}
+
+if (!function_exists('load_plugin_textdomain')) {
+    function load_plugin_textdomain(string $domain, bool $deprecated = false, string $pluginRelPath = ''): void
+    {
+        // No-op en pruebas.
+    }
+}
+
+if (!function_exists('register_activation_hook')) {
+    /** @var array<string, callable> $GLOBALS['g3d_vendor_base_helper_activation_hooks'] */
+    $GLOBALS['g3d_vendor_base_helper_activation_hooks'] = [];
+
+    function register_activation_hook(string $file, callable $callback): void
+    {
+        $GLOBALS['g3d_vendor_base_helper_activation_hooks'][$file] = $callback;
+    }
+}
+
+if (!function_exists('register_deactivation_hook')) {
+    /** @var array<string, callable> $GLOBALS['g3d_vendor_base_helper_deactivation_hooks'] */
+    $GLOBALS['g3d_vendor_base_helper_deactivation_hooks'] = [];
+
+    function register_deactivation_hook(string $file, callable $callback): void
+    {
+        $GLOBALS['g3d_vendor_base_helper_deactivation_hooks'][$file] = $callback;
+    }
+}


### PR DESCRIPTION
## Summary
- add CDN route builder, plugin paths resolver, and vendor guard utilities for the helper plugin
- wire plugin bootstrap with PSR-4 autoloading, activation guard, and localization loading
- add PHPUnit configuration, bootstrap, and coverage for the new helper plus update Composer scripts for checks

## Testing
- composer phpcs
- composer phpstan
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68daff9c97f8832387f48f708872a5de