### PR TITLE
feat(p5): endpoint de escritura de auditoría (Admin & Ops)

### DIFF
--- a/plugins/g3d-admin-ops/plugin.php
+++ b/plugins/g3d-admin-ops/plugin.php
@@ -44,4 +44,5 @@ add_action('rest_api_init', static function (): void {
     $reader = new \G3D\AdminOps\Audit\InMemoryEditorialActionLogger();
     // TODO(doc §persistencia): sustituir por almacenamiento persistente cuando esté definido.
     (new \G3D\AdminOps\Api\AuditReadController($reader))->registerRoutes();
+    (new \G3D\AdminOps\Api\AuditWriteController($reader))->registerRoutes();
 });

--- a/plugins/g3d-admin-ops/src/Api/AuditWriteController.php
+++ b/plugins/g3d-admin-ops/src/Api/AuditWriteController.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\AdminOps\Api;
+
+use DateTimeImmutable;
+use G3D\AdminOps\Audit\EditorialActionLogger;
+use G3D\AdminOps\Rbac\Capabilities;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * @phpstan-type AuditLogContext array{
+ *   what: string,
+ *   occurred_at?: string,
+ *   snapshot_id?: string,
+ *   resultado?: string,
+ *   latency_ms?: int
+ * }
+ * @phpstan-type AuditLogPayload array{
+ *   actor_id: string,
+ *   action: string,
+ *   context: AuditLogContext
+ * }
+ */
+final class AuditWriteController
+{
+    public function __construct(private EditorialActionLogger $logger)
+    {
+    }
+
+    public function registerRoutes(): void
+    {
+        register_rest_route(
+            'g3d/v1',
+            '/admin-ops/audit/log',
+            [
+                'methods' => 'POST',
+                'callback' => [$this, 'handle'],
+                'permission_callback' => static fn (): bool => current_user_can(
+                    Capabilities::CAP_MANAGE_PUBLICATION
+                ),
+            ]
+        );
+    }
+
+    public function handle(WP_REST_Request $req): WP_REST_Response|WP_Error
+    {
+        if (!current_user_can(Capabilities::CAP_MANAGE_PUBLICATION)) {
+            return new WP_Error('rest_forbidden', 'Forbidden', ['status' => 403]);
+        }
+
+        /** @var array<string,mixed> $payload */
+        $payload = $req->get_json_params();
+
+        $missingFields = [];
+        $typeErrors = [];
+
+        $actorId = $payload['actor_id'] ?? null;
+        if (!array_key_exists('actor_id', $payload)) {
+            $missingFields[] = 'actor_id';
+        } elseif (!is_string($actorId) || $actorId === '') {
+            $typeErrors[] = 'actor_id';
+        }
+
+        $action = $payload['action'] ?? null;
+        if (!array_key_exists('action', $payload)) {
+            $missingFields[] = 'action';
+        } elseif (!is_string($action) || $action === '') {
+            $typeErrors[] = 'action';
+        }
+
+        $rawContext = null;
+        if (!array_key_exists('context', $payload)) {
+            $missingFields[] = 'context';
+        } elseif (!is_array($payload['context'])) {
+            $typeErrors[] = 'context';
+        } else {
+            /** @var array<string,mixed> $rawContextCandidate */
+            $rawContextCandidate = $payload['context'];
+            $rawContext = $rawContextCandidate;
+        }
+
+        if (is_array($rawContext)) {
+            $what = $rawContext['what'] ?? null;
+            if (!array_key_exists('what', $rawContext)) {
+                $missingFields[] = 'context.what';
+            } elseif (!is_string($what) || $what === '') {
+                $typeErrors[] = 'context.what';
+            }
+        }
+
+        if (is_array($rawContext) && isset($rawContext['occurred_at'])) {
+            if (!is_string($rawContext['occurred_at']) || $rawContext['occurred_at'] === '') {
+                $typeErrors[] = 'context.occurred_at';
+            } elseif (!$this->isIso8601($rawContext['occurred_at'])) {
+                $typeErrors[] = 'context.occurred_at';
+            }
+        }
+
+        if (is_array($rawContext) && isset($rawContext['snapshot_id']) && !is_string($rawContext['snapshot_id'])) {
+            $typeErrors[] = 'context.snapshot_id';
+        }
+
+        if (is_array($rawContext) && isset($rawContext['resultado']) && !is_string($rawContext['resultado'])) {
+            $typeErrors[] = 'context.resultado';
+        }
+
+        if (is_array($rawContext) && isset($rawContext['latency_ms']) && !is_int($rawContext['latency_ms'])) {
+            $typeErrors[] = 'context.latency_ms';
+        }
+
+        if ($missingFields !== []) {
+            return new WP_Error(
+                'rest_missing_required_params',
+                'Faltan campos requeridos.',
+                [
+                    'status' => 400,
+                    'missing_fields' => $missingFields,
+                ]
+            );
+        }
+
+        if ($typeErrors !== []) {
+            return new WP_Error(
+                'rest_invalid_param',
+                'Tipos inválidos detectados.',
+                [
+                    'status' => 400,
+                    'type_errors' => $typeErrors,
+                ]
+            );
+        }
+
+        \assert(is_array($rawContext));
+
+        /** @var AuditLogContext $context */
+        $context = [
+            'what' => $rawContext['what'],
+        ];
+
+        if (isset($rawContext['occurred_at'])) {
+            $context['occurred_at'] = $rawContext['occurred_at'];
+        }
+
+        if (isset($rawContext['snapshot_id'])) {
+            $context['snapshot_id'] = $rawContext['snapshot_id'];
+        }
+
+        if (isset($rawContext['resultado'])) {
+            $context['resultado'] = $rawContext['resultado'];
+        }
+
+        if (isset($rawContext['latency_ms'])) {
+            $context['latency_ms'] = $rawContext['latency_ms'];
+        }
+
+        /** @var string $actorId */
+        /** @var string $action */
+        $this->logger->logAction($actorId, $action, $context);
+
+        return new WP_REST_Response(['ok' => true], 200);
+    }
+
+    private function isIso8601(string $value): bool
+    {
+        $date = DateTimeImmutable::createFromFormat(DATE_ATOM, $value);
+        if ($date === false) {
+            return false;
+        }
+
+        $errors = DateTimeImmutable::getLastErrors();
+        if ($errors === false) {
+            return true;
+        }
+
+        return $errors['warning_count'] === 0 && $errors['error_count'] === 0;
+    }
+}

--- a/plugins/g3d-admin-ops/tests/Api/AuditWriteRouteTest.php
+++ b/plugins/g3d-admin-ops/tests/Api/AuditWriteRouteTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\AdminOps\Tests\Api;
+
+use G3D\AdminOps\Api\AuditWriteController;
+use G3D\AdminOps\Audit\InMemoryEditorialActionLogger;
+use PHPUnit\Framework\TestCase;
+use Test_Env\Perms;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class AuditWriteRouteTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Perms::denyAll();
+    }
+
+    public function testForbiddenWhenNoCapability(): void
+    {
+        $controller = new AuditWriteController(new InMemoryEditorialActionLogger());
+        $response = $controller->handle($this->makeRequest([
+            'actor_id' => 'user:1',
+            'action' => 'publish',
+            'context' => ['what' => 'modelo:rx-classic'],
+        ]));
+
+        self::assertInstanceOf(WP_Error::class, $response);
+        self::assertSame(403, $response->get_error_data()['status'] ?? null);
+    }
+
+    public function testBadRequestWhenMissingRequired(): void
+    {
+        Perms::allowAll();
+        $controller = new AuditWriteController(new InMemoryEditorialActionLogger());
+        $response = $controller->handle($this->makeRequest([
+            'actor_id' => 'user:1',
+            'action' => 'publish',
+            'context' => [],
+        ]));
+
+        self::assertInstanceOf(WP_Error::class, $response);
+        self::assertSame(400, $response->get_error_data()['status'] ?? null);
+        $missing = $response->get_error_data()['missing_fields'] ?? [];
+        self::assertContains('context.what', $missing);
+    }
+
+    public function testOkWhenValidPayload(): void
+    {
+        Perms::allowAll();
+        $logger = new InMemoryEditorialActionLogger();
+        $controller = new AuditWriteController($logger);
+        $response = $controller->handle($this->makeRequest([
+            'actor_id' => 'user:42',
+            'action' => 'publish',
+            'context' => [
+                'what' => 'modelo:rx-classic',
+                'snapshot_id' => 'snap-01',
+                'resultado' => 'ok',
+                'latency_ms' => 123,
+            ],
+        ]));
+
+        self::assertInstanceOf(WP_REST_Response::class, $response);
+        self::assertSame(200, $response->get_status());
+        $data = $response->get_data();
+        self::assertTrue($data['ok'] ?? false);
+
+        $events = $logger->getEvents();
+        self::assertCount(1, $events);
+        self::assertSame('user:42', $events[0]['actor_id']);
+        self::assertSame('modelo:rx-classic', $events[0]['what']);
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     */
+    private function makeRequest(array $payload): WP_REST_Request
+    {
+        $request = new WP_REST_Request('POST', '/g3d/v1/admin-ops/audit/log');
+        $request->set_header('Content-Type', 'application/json');
+        $json = json_encode($payload);
+        self::assertIsString($json);
+        $request->set_body($json);
+
+        return $request;
+    }
+}


### PR DESCRIPTION
## Summary
- add AuditWriteController with POST g3d/v1/admin-ops/audit/log including permission gate and payload validation
- register the write endpoint alongside the read endpoint sharing the in-memory logger instance
- cover forbidden, validation error, and happy-path flows with new API tests

## Testing
- composer phpcs
- composer phpstan
- composer test
- vendor/bin/phpunit --configuration plugins/g3d-admin-ops/phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68db087610408323b4f264d289ef68e2