### PR TITLE
feat(p1): ingesta mínima GLB (sha256 + size) + validation shape + tests

### DIFF
--- a/plugins/g3d-models-manager/src/Service/GlbIngestionService.php
+++ b/plugins/g3d-models-manager/src/Service/GlbIngestionService.php
@@ -4,226 +4,99 @@ declare(strict_types=1);
 
 namespace G3D\ModelsManager\Service;
 
+use RuntimeException;
+
 /**
- * @phpstan-type Binding = array{
- *     file_hash: string,
- *     filesize_bytes: int,
- *     draco_enabled: bool,
- *     bounding_box: array{
- *         min: array{float, float, float},
- *         max: array{float, float, float}
- *     },
- *     piece_type: 'FRAME'|'TEMPLE'|'BRIDGE'|string,
- *     slots_detectados: list<string>,
- *     anchors_present: list<string>,
- *     props: array<string, scalar|null>,
- *     object_name: string,
- *     object_name_pattern: string,
- *     model_code: string
+ * @phpstan-type TypeError array{field:string, expected:string}
+ * @phpstan-type Validation array{
+ *   missing: list<string>,
+ *   type:    list<TypeError>,
+ *   ok:      bool
  * }
- * @phpstan-type TypeError = array{field: string, expected: string}
- * @phpstan-type Validation = array{
- *     missing: list<string>,
- *     type: list<TypeError>,
- *     ok: bool
- * }
- * @phpstan-type IngestionResult = array{
- *     binding: Binding,
- *     validation: Validation
+ * @phpstan-type IngestionResult array{
+ *   binding:    array<string,mixed>,
+ *   validation: Validation
  * }
  */
 final class GlbIngestionService
 {
     /**
-     * @param array{name:string,tmp_name:string,size:int,type?:string,error?:int} $uploaded
-     * @return array{binding: array<string, mixed>, validation: array<string, mixed>}
-     * @phpstan-return IngestionResult
+     * @param array<string,mixed> $file  $_FILES['...']-like: tmp_name, name, size, error
+     * @return IngestionResult
      */
-    public function ingest(array $uploaded): array
+    public function ingest(array $file): array
     {
-        $validation = [
-            'missing' => [],
-            'type' => [],
-            'ok' => true,
-        ];
+        $missing = [];
+        $type    = [];
 
-        if (!is_file($uploaded['tmp_name'])) {
-            $validation['missing'][] = 'g3d_glb_file';
-            $validation['ok'] = false;
+        if (!isset($file['tmp_name'])) {
+            $missing[] = 'tmp_name';
+        } elseif (!is_string($file['tmp_name'])) {
+            $type[] = ['field' => 'tmp_name', 'expected' => 'string'];
+        }
 
+        if (!isset($file['name'])) {
+            $missing[] = 'name';
+        } elseif (!is_string($file['name'])) {
+            $type[] = ['field' => 'name', 'expected' => 'string'];
+        }
+
+        if (!isset($file['size'])) {
+            $missing[] = 'size';
+        } elseif (!is_int($file['size'])) {
+            $type[] = ['field' => 'size', 'expected' => 'int'];
+        }
+
+        if ($missing !== [] || $type !== []) {
             return [
-                'binding' => $this->emptyBinding(),
-                'validation' => $validation,
+                'binding' => [],
+                'validation' => [
+                    'missing' => $missing,
+                    'type'    => $type,
+                    'ok'      => false,
+                ],
             ];
         }
 
-        $bytes = file_get_contents($uploaded['tmp_name']);
-        if ($bytes === false) {
-            $bytes = '';
+        /** @var string $tmp */
+        $tmp = $file['tmp_name'];
+        if (!is_readable($tmp)) {
+            return [
+                'binding' => [],
+                'validation' => [
+                    'missing' => [],
+                    'type'    => [['field' => 'tmp_name', 'expected' => 'readable path']],
+                    'ok'      => false,
+                ],
+            ];
         }
 
-        $hash = hash('sha256', $bytes);
-        $size = strlen($bytes);
-        $baseName = pathinfo($uploaded['name'], PATHINFO_FILENAME);
-        if ($baseName === '') {
-            $baseName = 'model';
+        // Tamaño: si `size` viene fiable, úsalo; si no, intenta `filesize()`.
+        /** @var int $declaredSize */
+        $declaredSize = $file['size'];
+        $sizeBytes = $declaredSize > 0 ? $declaredSize : (is_int(@filesize($tmp)) ? (int) @filesize($tmp) : 0);
+
+        // Hash SHA-256 del contenido (determinista).
+        $hash = @hash_file('sha256', $tmp);
+        if ($hash === false) {
+            throw new RuntimeException('No se pudo calcular SHA-256 del archivo.');
         }
 
+        // Construye binding **solo** con datos ciertos.
         $binding = [
-            'file_hash' => $hash,
-            'filesize_bytes' => $size,
-            'draco_enabled' => $this->isDracoEnabled($hash),
-            'bounding_box' => $this->buildBoundingBox($hash),
-            'piece_type' => 'FRAME',
-            'object_name' => $this->buildObjectName($baseName),
-            'object_name_pattern' => $this->buildObjectNamePattern($baseName),
-            'model_code' => $this->buildModelCode($baseName, $hash),
-            'props' => $this->buildProps($hash),
-            'anchors_present' => $this->buildAnchors($hash),
-            'slots_detectados' => $this->buildSlots($hash),
+            'file_hash'      => $hash,
+            'filesize_bytes' => $sizeBytes,
+            // No inventar: draco_enabled, bounding_box, slots_detectados, anchors_present, props...
+            // TODO(doc P1 §binding): rellenar cuando haya parsing GLB definitivo.
         ];
 
         return [
             'binding' => $binding,
-            'validation' => $validation,
-        ];
-    }
-
-    /**
-     * @return array<string, mixed>
-     * @phpstan-return Binding
-     */
-    private function emptyBinding(): array
-    {
-        return [
-            'file_hash' => '',
-            'filesize_bytes' => 0,
-            'draco_enabled' => false,
-            'bounding_box' => [
-                'min' => [0.0, 0.0, 0.0],
-                'max' => [0.0, 0.0, 0.0],
-            ],
-            'piece_type' => 'FRAME',
-            'object_name' => '',
-            'object_name_pattern' => '',
-            'model_code' => '',
-            'props' => [
-                'socket_width_mm' => 0.0,
-                'socket_height_mm' => 0.0,
-                'variant' => 'R',
-                'mount_type' => 'FRAMED',
-                'tol_w_mm' => 0.0,
-                'tol_h_mm' => 0.0,
-            ],
-            'anchors_present' => [],
-            'slots_detectados' => [],
-        ];
-    }
-
-    private function isDracoEnabled(string $hash): bool
-    {
-        return (hexdec($this->getHexSegment($hash, 0, 2)) % 2) === 0;
-    }
-
-    /**
-     * @return array{min: array{float, float, float}, max: array{float, float, float}}
-     */
-    private function buildBoundingBox(string $hash): array
-    {
-        $extentX = $this->normalizeHexToRange($this->getHexSegment($hash, 2, 6), 0.1, 1.5);
-        $extentY = $this->normalizeHexToRange($this->getHexSegment($hash, 8, 6), 0.1, 1.5);
-        $extentZ = $this->normalizeHexToRange($this->getHexSegment($hash, 14, 6), 0.1, 1.5);
-
-        return [
-            'min' => [
-                -$extentX,
-                -$extentY,
-                -$extentZ,
-            ],
-            'max' => [
-                $extentX,
-                $extentY,
-                $extentZ,
+            'validation' => [
+                'missing' => [],
+                'type'    => [],
+                'ok'      => true,
             ],
         ];
-    }
-
-    private function buildObjectName(string $baseName): string
-    {
-        return $baseName . '_FRAME';
-    }
-
-    private function buildObjectNamePattern(string $baseName): string
-    {
-        return strtoupper($baseName) . '_*';
-    }
-
-    private function buildModelCode(string $baseName, string $hash): string
-    {
-        $suffix = strtoupper(substr($hash, 0, 6));
-
-        return strtoupper($baseName) . '-' . $suffix;
-    }
-
-    /**
-     * @return array<string, scalar|null>
-     */
-    private function buildProps(string $hash): array
-    {
-        return [
-            'socket_width_mm' => $this->normalizeHexToRange($this->getHexSegment($hash, 20, 6), 40.0, 70.0),
-            'socket_height_mm' => $this->normalizeHexToRange($this->getHexSegment($hash, 26, 6), 25.0, 60.0),
-            'variant' => (hexdec($this->getHexSegment($hash, 32, 2)) % 2) === 0 ? 'R' : 'U',
-            'mount_type' => 'FRAMED',
-            'tol_w_mm' => $this->normalizeHexToRange($this->getHexSegment($hash, 34, 4), 0.05, 0.5),
-            'tol_h_mm' => $this->normalizeHexToRange($this->getHexSegment($hash, 38, 4), 0.05, 0.5),
-        ];
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function buildAnchors(string $hash): array
-    {
-        $anchors = [];
-        $anchors[] = 'FRAME_ANCHOR_' . strtoupper($this->getHexSegment($hash, 42, 4));
-        $anchors[] = 'TEMPLE_L_ANCHOR_' . strtoupper($this->getHexSegment($hash, 46, 4));
-        $anchors[] = 'TEMPLE_R_ANCHOR_' . strtoupper($this->getHexSegment($hash, 50, 4));
-
-        return $anchors;
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function buildSlots(string $hash): array
-    {
-        $slotBase = strtoupper($this->getHexSegment($hash, 54, 6));
-
-        return [
-            'MAT_' . $slotBase,
-        ];
-    }
-
-    private function normalizeHexToRange(string $hex, float $min, float $max): float
-    {
-        $hex = $hex !== '' ? $hex : '0';
-        $value = hexdec($hex);
-        $maxValue = (16 ** strlen($hex)) - 1;
-
-        $ratio = $value / $maxValue;
-        $normalized = $min + ($max - $min) * $ratio;
-
-        return round($normalized, 6);
-    }
-
-    private function getHexSegment(string $hash, int $offset, int $length): string
-    {
-        $segment = substr($hash, $offset, $length);
-        if ($segment === '') {
-            return '0';
-        }
-
-        return $segment;
     }
 }


### PR DESCRIPTION
## Summary
- compute SHA-256 hash and file size for uploaded GLB files in the ingestion service
- surface minimal binding data and validation feedback without fabricating GLB metadata
- cover ingestion success and validation failure scenarios with unit tests

## Testing
- composer phpcs
- composer phpstan
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68db13ca8abc83238d9472f17c6383bc