### PR TITLE
feat(vendor): endpoint de health-check (GET /g3d/v1/health) + tests

### DIFF
--- a/plugins/g3d-vendor-base-helper/plugin.php
+++ b/plugins/g3d-vendor-base-helper/plugin.php
@@ -35,6 +35,10 @@ add_action('init', static function (): void {
     load_plugin_textdomain('g3d-vendor-base-helper', false, dirname(plugin_basename(__FILE__)) . '/languages');
 });
 
+add_action('rest_api_init', static function (): void {
+    (new \G3D\VendorBase\Api\HealthController())->registerRoutes();
+});
+
 register_activation_hook(__FILE__, static function (): void {
     \G3D\VendorBase\Security\VendorGuard::assertReady();
 });

--- a/plugins/g3d-vendor-base-helper/src/Api/HealthController.php
+++ b/plugins/g3d-vendor-base-helper/src/Api/HealthController.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Api;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class HealthController
+{
+    public function registerRoutes(): void
+    {
+        \register_rest_route(
+            'g3d/v1',
+            '/health',
+            [
+                'methods' => 'GET',
+                'callback' => [$this, 'handle'],
+                // Health es público (no contiene secretos). Si los docs piden restricción, cámbialo.
+                'permission_callback' => '__return_true',
+            ]
+        );
+    }
+
+    public function handle(WP_REST_Request $req): WP_REST_Response
+    {
+        unset($req);
+
+        $phpVersion = \PHP_VERSION;
+        $wpAvailable = \function_exists('get_option') && \function_exists('register_rest_route');
+        $plugins = self::collectLocalPlugins();
+
+        return new WP_REST_Response(
+            [
+                'ok' => true,
+                'php_version' => $phpVersion,
+                'wp_available' => $wpAvailable,
+                'plugins' => $plugins,
+            ],
+            200
+        );
+    }
+
+    /**
+     * @return list<array{slug: string, version: string|null}>
+     */
+    private static function collectLocalPlugins(): array
+    {
+        $slugs = [
+            'g3d-vendor-base-helper',
+            'g3d-catalog-rules',
+            'g3d-models-manager',
+            'g3d-validate-sign',
+            'gafas3d-wizard-modal',
+            'g3d-admin-ops',
+        ];
+
+        /** @var list<array{slug: string, version: string|null}> $plugins */
+        $plugins = [];
+
+        foreach ($slugs as $slug) {
+            $version = self::tryReadLocalVersion($slug);
+            $plugins[] = [
+                'slug' => $slug,
+                'version' => $version,
+            ];
+        }
+
+        return $plugins;
+    }
+
+    private static function tryReadLocalVersion(string $slug): ?string
+    {
+        $pluginsRoot = \dirname(__DIR__, 3);
+        $pluginPhp = $pluginsRoot . '/' . $slug . '/plugin.php';
+
+        if (!\is_file($pluginPhp) || !\is_readable($pluginPhp)) {
+            // TODO(doc): documentar detección de versión cuando no hay plugin.php legible.
+            return null;
+        }
+
+        $fh = @\fopen($pluginPhp, 'r');
+        if ($fh === false) {
+            // TODO(doc): documentar detección de versión cuando no se puede abrir plugin.php.
+            return null;
+        }
+
+        $version = null;
+        $maxLines = 30;
+
+        while (!\feof($fh) && $maxLines-- > 0) {
+            $line = (string) \fgets($fh);
+            if (\stripos($line, 'Version:') === false) {
+                continue;
+            }
+
+            $parts = \explode(':', $line, 2);
+            if (!isset($parts[1])) {
+                continue;
+            }
+
+            $candidate = \trim($parts[1]);
+            if ($candidate === '') {
+                continue;
+            }
+
+            $version = $candidate;
+            break;
+        }
+
+        \fclose($fh);
+
+        // TODO(doc): si en futuro hay constantes VERSION por plugin, intentar leerlas sin eval.
+        return $version;
+    }
+}

--- a/plugins/g3d-vendor-base-helper/tests/Api/HealthControllerTest.php
+++ b/plugins/g3d-vendor-base-helper/tests/Api/HealthControllerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Tests\Api;
+
+use G3D\VendorBase\Api\HealthController;
+use PHPUnit\Framework\TestCase;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class HealthControllerTest extends TestCase
+{
+    public function testHealthReturnsOkAndVersionsShape(): void
+    {
+        $controller = new HealthController();
+        $response = $controller->handle(new WP_REST_Request());
+
+        self::assertInstanceOf(WP_REST_Response::class, $response);
+        self::assertSame(200, $response->get_status());
+
+        /**
+         * @var array{
+         *     ok: bool,
+         *     php_version: string,
+         *     wp_available: bool,
+         *     plugins: list<array{slug: string, version: string|null}>
+         * } $data
+         */
+        $data = $response->get_data();
+
+        self::assertTrue($data['ok']);
+        self::assertIsString($data['php_version']);
+        self::assertIsBool($data['wp_available']);
+        self::assertIsArray($data['plugins']);
+
+        foreach ($data['plugins'] as $plugin) {
+            self::assertArrayHasKey('slug', $plugin);
+            self::assertArrayHasKey('version', $plugin);
+            self::assertIsString($plugin['slug']);
+            $version = $plugin['version'];
+
+            if ($version !== null) {
+                self::assertIsString($version);
+            } else {
+                self::assertNull($version);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose the public g3d/v1/health endpoint that reports runtime info and plugin versions
- wire the new health controller during rest_api_init in the vendor helper bootstrap
- add unit coverage for the controller response shape

## Testing
- composer test
- composer phpcs
- composer phpstan

Tags: codex, observability, rest

------
https://chatgpt.com/codex/tasks/task_e_68db245706608323a5ce9d34c3f9193c