### PR TITLE
feat(p4): bootstrap admin assets (inline JS/CSS) + interacción básica modal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "phpstan": "vendor/bin/phpstan analyse --memory-limit=512M",
         "test": [
             "vendor/bin/phpunit --configuration plugins/g3d-catalog-rules/phpunit.xml.dist",
-            "vendor/bin/phpunit --configuration plugins/g3d-vendor-base-helper/phpunit.xml.dist"
+            "vendor/bin/phpunit --configuration plugins/g3d-vendor-base-helper/phpunit.xml.dist",
+            "vendor/bin/phpunit --configuration plugins/gafas3d-wizard-modal/phpunit.xml.dist"
         ]
     }
 }

--- a/plugins/gafas3d-wizard-modal/phpunit.xml.dist
+++ b/plugins/gafas3d-wizard-modal/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         cacheResult="false">
+    <testsuites>
+        <testsuite name="Gafas3D Wizard Modal">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/plugins/gafas3d-wizard-modal/plugin.php
+++ b/plugins/gafas3d-wizard-modal/plugin.php
@@ -13,6 +13,8 @@
 
 declare(strict_types=1);
 
+use Gafas3d\WizardModal\Admin\Assets as AdminAssets;
+use Gafas3d\WizardModal\Admin\Page as AdminPage;
 use Gafas3d\WizardModal\PublicAssets\Assets;
 use Gafas3d\WizardModal\Shortcode\WizardShortcode;
 
@@ -39,6 +41,14 @@ spl_autoload_register(static function (string $class): void {
 add_action('init', static function (): void {
     load_plugin_textdomain('gafas3d-wizard-modal', false, dirname(plugin_basename(__FILE__)) . '/languages');
     WizardShortcode::register();
+});
+
+add_action('admin_menu', static function (): void {
+    AdminPage::register();
+});
+
+add_action('plugins_loaded', static function (): void {
+    (new AdminAssets())->register();
 });
 
 add_action('wp_enqueue_scripts', [Assets::class, 'register']);

--- a/plugins/gafas3d-wizard-modal/src/Admin/Assets.php
+++ b/plugins/gafas3d-wizard-modal/src/Admin/Assets.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gafas3d\WizardModal\Admin;
+
+use function add_action;
+use function is_string;
+use function wp_add_inline_script;
+use function wp_add_inline_style;
+use function wp_enqueue_script;
+use function wp_enqueue_style;
+use function wp_register_script;
+use function wp_register_style;
+use function wp_json_encode;
+
+final class Assets
+{
+    private string $handle = 'g3d-wizard-modal-admin';
+
+    public function register(): void
+    {
+        add_action('admin_enqueue_scripts', function (): void {
+            $page = $_GET['page'] ?? null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+            if (!is_string($page) || $page !== Page::MENU_SLUG) {
+                return;
+            }
+
+            $this->enqueueStyle();
+            $this->enqueueScript();
+        });
+    }
+
+    private function enqueueStyle(): void
+    {
+        wp_register_style($this->handle, false, [], null);
+        wp_enqueue_style($this->handle);
+        wp_add_inline_style($this->handle, $this->style());
+    }
+
+    private function enqueueScript(): void
+    {
+        wp_register_script($this->handle, '', [], null, true);
+        wp_enqueue_script($this->handle);
+        wp_add_inline_script($this->handle, $this->script());
+    }
+
+    private function style(): string
+    {
+        return <<<CSS
+.g3d-wizard-modal__overlay[hidden] {
+    display: none;
+}
+
+.g3d-wizard-modal__overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 5vh 2rem;
+    background: rgba(0, 0, 0, 0.55);
+    overflow-y: auto;
+    z-index: 100000;
+}
+
+.g3d-wizard-modal {
+    width: 100%;
+    max-width: 960px;
+    margin: 5vh auto;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 24px 48px rgba(0, 0, 0, 0.25);
+}
+
+.g3d-wizard-modal__content {
+    padding: 24px;
+}
+
+.g3d-wizard-modal__header,
+.g3d-wizard-modal__footer {
+    padding: 0 24px 24px;
+}
+CSS;
+    }
+
+    private function script(): string
+    {
+        $focusableSelector = wp_json_encode(
+            'a[href], button:not([disabled]), textarea, input, select, '
+            . '[tabindex]:not([tabindex="-1"])'
+        );
+
+        return <<<JS
+(function () {
+    const overlay = document.querySelector('[data-g3d-wizard-modal-overlay]');
+    if (!overlay) {
+        return;
+    }
+
+    const modal = overlay.querySelector('.g3d-wizard-modal');
+    if (!modal) {
+        return;
+    }
+
+    const openers = document.querySelectorAll('[data-g3d-wizard-modal-open]');
+    const closers = overlay.querySelectorAll('[data-g3d-wizard-modal-close]');
+    const focusGuards = overlay.querySelectorAll('[data-g3d-wizard-focus-guard]');
+    const focusableSelector = {$focusableSelector};
+    let lastTrigger = null;
+
+    function getFocusableElements() {
+        return Array.from(modal.querySelectorAll(focusableSelector))
+            .filter(function (element) {
+                return !element.hasAttribute('disabled')
+                    && element.getAttribute('aria-hidden') !== 'true'
+                    && element.offsetParent !== null;
+            });
+    }
+
+    function focusInitialElement() {
+        const focusable = getFocusableElements();
+        if (focusable.length > 0) {
+            focusable[0].focus();
+            return;
+        }
+
+        modal.focus();
+    }
+
+    function onKeydown(event) {
+        if (event.key !== 'Escape' && event.key !== 'Esc') {
+            return;
+        }
+
+        if (overlay.hasAttribute('hidden')) {
+            return;
+        }
+
+        event.preventDefault();
+        closeModal();
+    }
+
+    function openModal(trigger) {
+        lastTrigger = trigger || document.activeElement;
+        overlay.removeAttribute('hidden');
+        focusInitialElement();
+        document.addEventListener('keydown', onKeydown);
+    }
+
+    function closeModal() {
+        overlay.setAttribute('hidden', '');
+        document.removeEventListener('keydown', onKeydown);
+
+        if (lastTrigger && typeof lastTrigger.focus === 'function') {
+            lastTrigger.focus();
+        }
+    }
+
+    openers.forEach(function (opener) {
+        opener.addEventListener('click', function (event) {
+            event.preventDefault();
+            openModal(opener);
+        });
+    });
+
+    closers.forEach(function (closer) {
+        closer.addEventListener('click', function (event) {
+            event.preventDefault();
+            closeModal();
+        });
+    });
+
+    focusGuards.forEach(function (guard) {
+        guard.addEventListener('focus', function () {
+            if (overlay.hasAttribute('hidden')) {
+                return;
+            }
+
+            const focusable = getFocusableElements();
+
+            if (focusable.length === 0) {
+                modal.focus();
+                return;
+            }
+
+            if (guard.dataset.g3dWizardFocusGuard === 'start') {
+                focusable[focusable.length - 1].focus();
+                return;
+            }
+
+            if (guard.dataset.g3dWizardFocusGuard === 'end') {
+                focusable[0].focus();
+            }
+        });
+    });
+})();
+JS;
+    }
+}

--- a/plugins/gafas3d-wizard-modal/tests/Admin/PageRenderTest.php
+++ b/plugins/gafas3d-wizard-modal/tests/Admin/PageRenderTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gafas3d\WizardModal\Tests\Admin;
+
+use Gafas3d\WizardModal\Admin\Page;
+use PHPUnit\Framework\TestCase;
+
+final class PageRenderTest extends TestCase
+{
+    public function testRenderOutputsExpectedMarkup(): void
+    {
+        ob_start();
+        Page::render();
+        $output = (string) ob_get_clean();
+
+        self::assertStringContainsString('id="gafas3d-wizard-modal-root"', $output);
+        self::assertStringContainsString('data-g3d-wizard-modal-open', $output);
+        self::assertStringContainsString('data-g3d-wizard-modal-close', $output);
+        self::assertStringContainsString('data-g3d-wizard-modal-overlay', $output);
+    }
+}

--- a/plugins/gafas3d-wizard-modal/tests/bootstrap.php
+++ b/plugins/gafas3d-wizard-modal/tests/bootstrap.php
@@ -1,0 +1,57 @@
+<?php
+// phpcs:ignoreFile
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../g3d-vendor-base-helper/tests/bootstrap.php';
+
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'Gafas3d\\WizardModal\\';
+
+    if (!str_starts_with($class, $prefix)) {
+        return;
+    }
+
+    $relative = substr($class, strlen($prefix));
+    $relativePath = str_replace('\\', '/', $relative);
+    $file = __DIR__ . '/../src/' . $relativePath . '.php';
+
+    if (is_file($file)) {
+        require_once $file;
+    }
+});
+
+if (!function_exists('__')) {
+    function __(string $text, string $domain = 'default'): string
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_attr')) {
+    function esc_attr(string $text): string
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_attr__')) {
+    function esc_attr__(string $text, string $domain = 'default'): string
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html(string $text): string
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_html__')) {
+    function esc_html__(string $text, string $domain = 'default'): string
+    {
+        return $text;
+    }
+}


### PR DESCRIPTION
## Summary
- add admin asset registrar that inlines minimal CSS/JS for the wizard admin page
- wire the admin page + assets into the plugin bootstrap and provide PHPUnit config
- cover the admin markup expectations with a render test and shared test bootstrap

## Testing
- composer test
- composer phpstan
- composer phpcs

Tags: codex, p4, admin, ux

------
https://chatgpt.com/codex/tasks/task_e_68db26d653408323bbd2554e0ae42ee2