### PR TITLE
chore(rest): smoke tests de registro de rutas + stubs add_action/do_action

### DIFF
--- a/plugins/g3d-admin-ops/tests/Routes/AuditRouteRegistrationTest.php
+++ b/plugins/g3d-admin-ops/tests/Routes/AuditRouteRegistrationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\AdminOps\Tests\Routes;
+
+use PHPUnit\Framework\TestCase;
+
+final class AuditRouteRegistrationTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        require_once __DIR__ . '/../../plugin.php';
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['g3d_tests_registered_rest_routes'] = [];
+    }
+
+    public function testAuditReadRouteRegistered(): void
+    {
+        \do_action('rest_api_init');
+
+        self::assertTrue(self::routeExists('g3d/v1', '/audit', 'GET'));
+    }
+
+    public function testAuditWriteRouteRegistered(): void
+    {
+        \do_action('rest_api_init');
+
+        self::assertTrue(self::routeExists('g3d/v1', '/audit', 'POST'));
+    }
+
+    private static function routeExists(string $ns, string $route, string $method): bool
+    {
+        /**
+         * @var list<array{namespace:string,route:string,args:array<string,mixed>}> $routes
+         */
+        $routes = $GLOBALS['g3d_tests_registered_rest_routes'];
+
+        foreach ($routes as $r) {
+            if ($r['namespace'] === $ns && $r['route'] === $route) {
+                $methods = $r['args']['methods'] ?? '';
+
+                return \is_string($methods) ? \str_contains($methods, $method) : false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/plugins/g3d-validate-sign/plugin.php
+++ b/plugins/g3d-validate-sign/plugin.php
@@ -13,10 +13,36 @@
 
 declare(strict_types=1);
 
+use G3D\ValidateSign\Api\ValidateSignController;
+use G3D\ValidateSign\Api\VerifyController;
+use G3D\ValidateSign\Crypto\Signer;
+use G3D\ValidateSign\Crypto\Verifier;
+use G3D\ValidateSign\Domain\Expiry;
+use G3D\ValidateSign\Validation\RequestValidator;
+
 if (!defined('ABSPATH')) {
     exit;
 }
 
 add_action('init', static function (): void {
     load_plugin_textdomain('g3d-validate-sign', false, dirname(plugin_basename(__FILE__)) . '/languages');
+});
+
+add_action('rest_api_init', static function (): void {
+    $schemaDir = __DIR__ . '/schemas';
+
+    $validateValidator = new RequestValidator($schemaDir . '/validate-sign.request.schema.json');
+    $verifyValidator = new RequestValidator($schemaDir . '/verify.request.schema.json');
+
+    $expiry = new Expiry();
+    $signer = new Signer();
+    $privateKey = defined('G3D_VALIDATE_SIGN_PRIVATE_KEY') ? (string) G3D_VALIDATE_SIGN_PRIVATE_KEY : '';
+    $validateController = new ValidateSignController($validateValidator, $signer, $expiry, $privateKey);
+
+    $verifier = new Verifier();
+    $publicKey = defined('G3D_VALIDATE_SIGN_PUBLIC_KEY') ? (string) G3D_VALIDATE_SIGN_PUBLIC_KEY : '';
+    $verifyController = new VerifyController($verifyValidator, $verifier, $expiry, $publicKey);
+
+    $validateController->registerRoutes();
+    $verifyController->registerRoutes();
 });

--- a/plugins/g3d-validate-sign/tests/Routes/RouteRegistrationTest.php
+++ b/plugins/g3d-validate-sign/tests/Routes/RouteRegistrationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\ValidateSign\Tests\Routes;
+
+use PHPUnit\Framework\TestCase;
+
+final class RouteRegistrationTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        require_once __DIR__ . '/../../plugin.php';
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['g3d_tests_registered_rest_routes'] = [];
+    }
+
+    public function testValidateSignRouteRegistered(): void
+    {
+        \do_action('rest_api_init');
+
+        self::assertTrue(self::routeExists('g3d/v1', '/validate-sign', 'POST'));
+    }
+
+    public function testVerifyRouteRegistered(): void
+    {
+        \do_action('rest_api_init');
+
+        self::assertTrue(self::routeExists('g3d/v1', '/verify', 'POST'));
+    }
+
+    private static function routeExists(string $ns, string $route, string $method): bool
+    {
+        /**
+         * @var list<array{namespace:string,route:string,args:array<string,mixed>}> $routes
+         */
+        $routes = $GLOBALS['g3d_tests_registered_rest_routes'];
+
+        foreach ($routes as $r) {
+            if ($r['namespace'] === $ns && $r['route'] === $route) {
+                $methods = $r['args']['methods'] ?? '';
+
+                return \is_string($methods) ? \str_contains($methods, $method) : false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/plugins/g3d-vendor-base-helper/tests/Routes/HealthRouteRegistrationTest.php
+++ b/plugins/g3d-vendor-base-helper/tests/Routes/HealthRouteRegistrationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Tests\Routes;
+
+use PHPUnit\Framework\TestCase;
+
+final class HealthRouteRegistrationTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        require_once __DIR__ . '/../../plugin.php';
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['g3d_tests_registered_rest_routes'] = [];
+    }
+
+    public function testHealthRouteRegistered(): void
+    {
+        \do_action('rest_api_init');
+
+        self::assertTrue(self::routeExists('g3d/v1', '/health', 'GET'));
+    }
+
+    private static function routeExists(string $ns, string $route, string $method): bool
+    {
+        /**
+         * @var list<array{namespace:string,route:string,args:array<string,mixed>}> $routes
+         */
+        $routes = $GLOBALS['g3d_tests_registered_rest_routes'];
+
+        foreach ($routes as $r) {
+            if ($r['namespace'] === $ns && $r['route'] === $route) {
+                $methods = $r['args']['methods'] ?? '';
+
+                return \is_string($methods) ? \str_contains($methods, $method) : false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/plugins/g3d-vendor-base-helper/tests/bootstrap.php
+++ b/plugins/g3d-vendor-base-helper/tests/bootstrap.php
@@ -88,6 +88,32 @@ if (!function_exists('register_rest_route')) {
     }
 }
 
+// --- Hooks WP mínimos para pruebas ---
+if (!isset($GLOBALS['g3d_tests_wp_actions'])) {
+    /** @var array<string, array<int, array{priority:int, cb:callable}>> $GLOBALS['g3d_tests_wp_actions'] */
+    $GLOBALS['g3d_tests_wp_actions'] = [];
+}
+
+if (!function_exists('add_action')) {
+    function add_action(string $hook, callable $cb, int $priority = 10, int $args = 1): void
+    {
+        $GLOBALS['g3d_tests_wp_actions'][$hook] ??= [];
+        $GLOBALS['g3d_tests_wp_actions'][$hook][] = ['priority' => $priority, 'cb' => $cb];
+    }
+}
+
+if (!function_exists('do_action')) {
+    function do_action(string $hook, mixed ...$params): void
+    {
+        $list = $GLOBALS['g3d_tests_wp_actions'][$hook] ?? [];
+        usort($list, static fn($a, $b) => $a['priority'] <=> $b['priority']);
+
+        foreach ($list as $item) {
+            ($item['cb'])(...$params);
+        }
+    }
+}
+
 if (!class_exists('WP_REST_Request')) {
     class WP_REST_Request
     {


### PR DESCRIPTION
## Summary
- stub minimal WordPress hooks in the shared test bootstrap so add_action/do_action can be exercised during smoke tests
- cover REST registrations with smoke tests for the vendor health endpoint, validate-sign routes, and admin-ops audit routes
- wire the validate-sign plugin into rest_api_init to register its REST controllers using the real services

## Testing
- composer test
- composer phpstan
- composer phpcs

------
https://chatgpt.com/codex/tasks/task_e_68db291fe050832383bd2410e5b6f5c0