### PR TITLE
chore(vendor): helpers REST (Responses + Security) unificados + tests

### DIFF
--- a/plugins/g3d-admin-ops/src/Api/AuditWriteController.php
+++ b/plugins/g3d-admin-ops/src/Api/AuditWriteController.php
@@ -74,6 +74,6 @@ final class AuditWriteController
             return new WP_REST_Response($err, 400);
         }
 
-        return new WP_REST_Response(['ok' => true], 201);
+        return new WP_REST_Response(Responses::ok(), 201);
     }
 }

--- a/plugins/g3d-catalog-rules/src/Api/RulesReadController.php
+++ b/plugins/g3d-catalog-rules/src/Api/RulesReadController.php
@@ -97,15 +97,14 @@ final class RulesReadController
         $productoId = isset($params['producto_id']) ? (string) $params['producto_id'] : '';
 
         if ($productoId === '') {
-            return new WP_REST_Response(
-                Responses::error(
-                    'g3d_catalog_rules_missing_producto_id',
-                    'g3d_catalog_rules_missing_producto_id',
-                    'Missing required query parameter: producto_id.',
-                    ['status' => 400]
-                ),
-                400
+            $error = Responses::error(
+                'g3d_catalog_rules_missing_producto_id',
+                'g3d_catalog_rules_missing_producto_id',
+                'Missing required query parameter: producto_id.'
             );
+            $error['status'] = 400;
+
+            return new WP_REST_Response($error, 400);
         }
 
         $locale = isset($params['locale']) ? (string) $params['locale'] : null;

--- a/plugins/g3d-validate-sign/src/Api/ValidateSignController.php
+++ b/plugins/g3d-validate-sign/src/Api/ValidateSignController.php
@@ -64,35 +64,29 @@ class ValidateSignController
         $validation = $this->validator->validate($payload);
 
         if (!empty($validation['missing'])) {
-            return new WP_REST_Response(
-                Responses::error(
-                    'rest_missing_required_params',
-                    'rest_missing_required_params',
-                    'Faltan campos requeridos.',
-                    [
-                        'status' => 400,
-                        'missing_fields' => $validation['missing'],
-                        'request_id' => $requestId,
-                    ]
-                ),
-                400
+            $error = Responses::error(
+                'rest_missing_required_params',
+                'rest_missing_required_params',
+                'Faltan campos requeridos.'
             );
+            $error['status'] = 400;
+            $error['missing_fields'] = $validation['missing'];
+            $error['request_id'] = $requestId;
+
+            return new WP_REST_Response($error, 400);
         }
 
         if (!empty($validation['type'])) {
-            return new WP_REST_Response(
-                Responses::error(
-                    'rest_invalid_param',
-                    'rest_invalid_param',
-                    'Tipos inválidos detectados.',
-                    [
-                        'status' => 400,
-                        'type_errors' => $validation['type'],
-                        'request_id' => $requestId,
-                    ]
-                ),
-                400
+            $error = Responses::error(
+                'rest_invalid_param',
+                'rest_invalid_param',
+                'Tipos inválidos detectados.'
             );
+            $error['status'] = 400;
+            $error['type_errors'] = $validation['type'];
+            $error['request_id'] = $requestId;
+
+            return new WP_REST_Response($error, 400);
         }
 
         // TODO: Validar snapshot, IDs y reglas de catálogo según docs/plugin-3-g3d-validate-sign.md §6.1.
@@ -107,15 +101,14 @@ class ValidateSignController
 // TODO: Calcular summary real (docs/Capa 1 Identificadores Y Naming —
 // Actualizada (slots Abiertos).md, plantilla resumen).
 
-        $response = [
-            'ok' => true,
+        $response = Responses::ok([
             'sku_hash' => $signing['sku_hash'],
             'sku_signature' => $signing['signature'],
             'expires_at' => $this->expiry->format($expiresAt),
             'snapshot_id' => $snapshotId,
             'summary' => $summary,
             'request_id' => $requestId,
-        ];
+        ]);
 
         if (array_key_exists('price', $payload)) {
             $response['price'] = is_numeric($payload['price']) ? (float) $payload['price'] : $payload['price'];

--- a/plugins/g3d-validate-sign/src/Api/VerifyController.php
+++ b/plugins/g3d-validate-sign/src/Api/VerifyController.php
@@ -64,35 +64,29 @@ class VerifyController
         $validation = $this->validator->validate($payload);
 
         if (!empty($validation['missing'])) {
-            return new WP_REST_Response(
-                Responses::error(
-                    'rest_missing_required_params',
-                    'rest_missing_required_params',
-                    'Faltan campos requeridos.',
-                    [
-                        'status' => 400,
-                        'missing_fields' => $validation['missing'],
-                        'request_id' => $requestId,
-                    ]
-                ),
-                400
+            $error = Responses::error(
+                'rest_missing_required_params',
+                'rest_missing_required_params',
+                'Faltan campos requeridos.'
             );
+            $error['status'] = 400;
+            $error['missing_fields'] = $validation['missing'];
+            $error['request_id'] = $requestId;
+
+            return new WP_REST_Response($error, 400);
         }
 
         if (!empty($validation['type'])) {
-            return new WP_REST_Response(
-                Responses::error(
-                    'rest_invalid_param',
-                    'rest_invalid_param',
-                    'Tipos inválidos detectados.',
-                    [
-                        'status' => 400,
-                        'type_errors' => $validation['type'],
-                        'request_id' => $requestId,
-                    ]
-                ),
-                400
+            $error = Responses::error(
+                'rest_invalid_param',
+                'rest_invalid_param',
+                'Tipos inválidos detectados.'
             );
+            $error['status'] = 400;
+            $error['type_errors'] = $validation['type'];
+            $error['request_id'] = $requestId;
+
+            return new WP_REST_Response($error, 400);
         }
 
         $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
@@ -103,9 +97,9 @@ class VerifyController
             $errorResponse = Responses::error(
                 $verification['code'],
                 $verification['reason_key'],
-                $verification['detail'],
-                ['request_id' => $requestId]
+                $verification['detail']
             );
+            $errorResponse['request_id'] = $requestId;
 
             return new WP_REST_Response($errorResponse, 400);
         }
@@ -117,17 +111,16 @@ class VerifyController
                 'E_SIGN_EXPIRED',
                 'sign_expired',
                 'Caducidad agotada (ver docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada '
-                    . '(slots Abiertos) — V2 (urls).md).',
-                ['request_id' => $requestId]
+                    . '(slots Abiertos) — V2 (urls).md).'
             );
+            $errorResponse['request_id'] = $requestId;
 
             return new WP_REST_Response($errorResponse, 400);
         }
 
-        $response = [
-            'ok' => true,
+        $response = Responses::ok([
             'request_id' => $requestId,
-        ];
+        ]);
 
         return new WP_REST_Response($response, 200);
     }

--- a/plugins/g3d-validate-sign/tests/Api/ValidateSignRouteTest.php
+++ b/plugins/g3d-validate-sign/tests/Api/ValidateSignRouteTest.php
@@ -98,6 +98,7 @@ final class ValidateSignRouteTest extends TestCase
         self::assertFalse($data['ok']);
         self::assertSame('rest_missing_required_params', $data['code']);
         self::assertSame('Faltan campos requeridos.', $data['detail']);
+        self::assertSame(400, $data['status']);
         self::assertArrayHasKey('request_id', $data);
         self::assertMatchesRegularExpression('/^[0-9a-f]{32}$/', (string) $data['request_id']);
     }
@@ -134,6 +135,7 @@ final class ValidateSignRouteTest extends TestCase
         self::assertFalse($data['ok']);
         self::assertSame('rest_invalid_param', $data['code']);
         self::assertArrayHasKey('type_errors', $data);
+        self::assertSame(400, $data['status']);
         self::assertArrayHasKey('request_id', $data);
         self::assertMatchesRegularExpression('/^[0-9a-f]{32}$/', (string) $data['request_id']);
     }

--- a/plugins/g3d-validate-sign/tests/Api/VerifyRouteTest.php
+++ b/plugins/g3d-validate-sign/tests/Api/VerifyRouteTest.php
@@ -92,6 +92,7 @@ final class VerifyRouteTest extends TestCase
         self::assertInstanceOf(WP_REST_Response::class, $response);
         self::assertSame(400, $response->get_status());
         $data = $response->get_data();
+        self::assertFalse($data['ok']);
         self::assertSame('E_SIGN_EXPIRED', $data['code']);
         self::assertSame('sign_expired', $data['reason_key']);
         self::assertMatchesRegularExpression('/^[0-9a-f]{32}$/', (string) $data['request_id']);
@@ -130,6 +131,7 @@ final class VerifyRouteTest extends TestCase
         self::assertInstanceOf(WP_REST_Response::class, $response);
         self::assertSame(400, $response->get_status());
         $data = $response->get_data();
+        self::assertFalse($data['ok']);
         self::assertSame('E_SIGN_SNAPSHOT_MISMATCH', $data['code']);
         self::assertSame('sign_snapshot_mismatch', $data['reason_key']);
         self::assertMatchesRegularExpression('/^[0-9a-f]{32}$/', (string) $data['request_id']);
@@ -169,6 +171,7 @@ final class VerifyRouteTest extends TestCase
         self::assertInstanceOf(WP_REST_Response::class, $response);
         self::assertSame(400, $response->get_status());
         $data = $response->get_data();
+        self::assertFalse($data['ok']);
         self::assertSame('E_SIGN_INVALID', $data['code']);
         self::assertSame('sign_invalid', $data['reason_key']);
         self::assertMatchesRegularExpression('/^[0-9a-f]{32}$/', (string) $data['request_id']);
@@ -207,6 +210,7 @@ final class VerifyRouteTest extends TestCase
         self::assertInstanceOf(WP_REST_Response::class, $response);
         self::assertSame(400, $response->get_status());
         $data = $response->get_data();
+        self::assertFalse($data['ok']);
         self::assertSame('E_SIGN_INVALID', $data['code']);
         self::assertSame('sign_invalid', $data['reason_key']);
         self::assertMatchesRegularExpression('/^[0-9a-f]{32}$/', (string) $data['request_id']);

--- a/plugins/g3d-vendor-base-helper/src/Rest/Responses.php
+++ b/plugins/g3d-vendor-base-helper/src/Rest/Responses.php
@@ -7,18 +7,24 @@ namespace G3D\VendorBase\Rest;
 final class Responses
 {
     /**
-     * Normaliza payload de error para consistencia entre controladores.
-     *
-     * @param array<string,mixed> $extra
+     * @param array<string,mixed> $data
      * @return array<string,mixed>
      */
-    public static function error(string $code, string $reasonKey, string $detail, array $extra = []): array
+    public static function ok(array $data = []): array
     {
-        return \array_merge([
+        return ['ok' => true] + $data;
+    }
+
+    /**
+     * @return array{ok:false,code:string,reason_key:string,detail:string}
+     */
+    public static function error(string $code, string $reasonKey, string $detail): array
+    {
+        return [
             'ok'         => false,
             'code'       => $code,
             'reason_key' => $reasonKey,
             'detail'     => $detail,
-        ], $extra);
+        ];
     }
 }

--- a/plugins/g3d-vendor-base-helper/src/Rest/Security.php
+++ b/plugins/g3d-vendor-base-helper/src/Rest/Security.php
@@ -10,62 +10,23 @@ use WP_REST_Request;
 final class Security
 {
     /**
-     * Verifica nonce REST si está presente. Si falta y los docs no lo requieren,
-     * no bloquea (best effort). Si los docs lo exigen, cambiar a "required".
-     *
      * @return true|WP_Error
      */
-    public static function checkOptionalNonce(WP_REST_Request $req, string $action = 'wp_rest'): true|WP_Error
+    public static function checkOptionalNonce(WP_REST_Request $req)
     {
-        // Header estándar de WP o query/body.
-        $provided = self::extractNonce($req);
-
-        if ($provided === null || $provided === '') {
-            // TODO(doc §auth): si el doc lo requiere, devolver WP_Error 401.
+        $nonce = $req->get_header('X-WP-Nonce') ?? $req->get_header('x-wp-nonce');
+        if ($nonce === null || $nonce === '') {
             return true;
         }
 
-        if (\function_exists('wp_verify_nonce') && \wp_verify_nonce($provided, $action)) {
+        if (\function_exists('wp_verify_nonce') && \wp_verify_nonce($nonce, 'wp_rest')) {
             return true;
         }
 
-        return new WP_Error('rest_invalid_nonce', 'Nonce inválido.', ['status' => 401]);
-    }
-
-    private static function extractNonce(WP_REST_Request $req): ?string
-    {
-        $header = $req->get_header('X-WP-Nonce');
-        if ($header !== null && $header !== '') {
-            return $header;
-        }
-
-        if (method_exists($req, 'get_param')) {
-            $param = $req->get_param('__nonce') ?? $req->get_param('_wpnonce');
-            if (is_string($param)) {
-                return $param;
-            }
-        }
-
-        if (method_exists($req, 'get_params')) {
-            $params = $req->get_params();
-            if (is_array($params)) {
-                $param = $params['__nonce'] ?? $params['_wpnonce'] ?? null;
-                if (is_string($param)) {
-                    return $param;
-                }
-            }
-        }
-
-        if (method_exists($req, 'get_body') && method_exists($req, 'get_json_params')) {
-            $params = $req->get_json_params();
-            if (is_array($params)) {
-                $param = $params['__nonce'] ?? $params['_wpnonce'] ?? null;
-                if (is_string($param)) {
-                    return $param;
-                }
-            }
-        }
-
-        return null;
+        return new WP_Error(
+            'rest_invalid_nonce',
+            'Nonce inválido.',
+            ['status' => 401]
+        );
     }
 }

--- a/plugins/g3d-vendor-base-helper/tests/Rest/ResponsesTest.php
+++ b/plugins/g3d-vendor-base-helper/tests/Rest/ResponsesTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Tests\Rest;
+
+use G3D\VendorBase\Rest\Responses;
+use PHPUnit\Framework\TestCase;
+
+final class ResponsesTest extends TestCase
+{
+    public function testOkReturnsOkFlagWhenNoDataProvided(): void
+    {
+        self::assertSame(['ok' => true], Responses::ok());
+    }
+
+    public function testOkMergesAdditionalPayload(): void
+    {
+        $result = Responses::ok(['foo' => 'bar']);
+
+        self::assertSame([
+            'ok' => true,
+            'foo' => 'bar',
+        ], $result);
+    }
+
+    public function testOkKeepsOkTrueWhenCallerProvidesKey(): void
+    {
+        $result = Responses::ok(['ok' => false, 'extra' => 1]);
+
+        self::assertSame([
+            'ok' => true,
+            'extra' => 1,
+        ], $result);
+    }
+
+    public function testErrorReturnsCanonicalShape(): void
+    {
+        $result = Responses::error('E_SAMPLE', 'sample_reason', 'Sample detail');
+
+        self::assertSame([
+            'ok' => false,
+            'code' => 'E_SAMPLE',
+            'reason_key' => 'sample_reason',
+            'detail' => 'Sample detail',
+        ], $result);
+    }
+}

--- a/plugins/g3d-vendor-base-helper/tests/Rest/SecurityTest.php
+++ b/plugins/g3d-vendor-base-helper/tests/Rest/SecurityTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Tests\Rest;
+
+use G3D\VendorBase\Rest\Security;
+use PHPUnit\Framework\TestCase;
+use Test_Env\Nonce;
+use WP_Error;
+use WP_REST_Request;
+
+final class SecurityTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Nonce::allow();
+        parent::tearDown();
+    }
+
+    public function testCheckOptionalNonceReturnsTrueWhenHeaderMissing(): void
+    {
+        $request = new WP_REST_Request('GET', '/g3d/v1/ping');
+
+        $result = Security::checkOptionalNonce($request);
+
+        self::assertTrue($result);
+    }
+
+    public function testCheckOptionalNonceReturnsTrueWhenNonceValid(): void
+    {
+        $request = new WP_REST_Request('POST', '/g3d/v1/ping');
+        $request->set_header('X-WP-Nonce', 'valid-nonce');
+        Nonce::allow();
+
+        $result = Security::checkOptionalNonce($request);
+
+        self::assertTrue($result);
+    }
+
+    public function testCheckOptionalNonceReturnsWpErrorWhenNonceInvalid(): void
+    {
+        $request = new WP_REST_Request('POST', '/g3d/v1/ping');
+        $request->set_header('X-WP-Nonce', 'invalid-nonce');
+        Nonce::deny();
+
+        $result = Security::checkOptionalNonce($request);
+
+        self::assertInstanceOf(WP_Error::class, $result);
+        self::assertSame('rest_invalid_nonce', $result->get_error_code());
+        self::assertSame(401, $result->get_error_data()['status'] ?? null);
+    }
+}

--- a/plugins/g3d-vendor-base-helper/tests/bootstrap.php
+++ b/plugins/g3d-vendor-base-helper/tests/bootstrap.php
@@ -260,14 +260,33 @@ if (!function_exists('current_user_can')) {
 if (!function_exists('wp_verify_nonce')) {
     function wp_verify_nonce(string $nonce, string $action = 'wp_rest'): bool
     {
-        // TODO(doc §auth)
-        return true;
+        return \Test_Env\Nonce::verify($nonce, $action);
     }
 }
 
 }
 
 namespace Test_Env {
+    final class Nonce
+    {
+        private static bool $allow = true;
+
+        public static function allow(): void
+        {
+            self::$allow = true;
+        }
+
+        public static function deny(): void
+        {
+            self::$allow = false;
+        }
+
+        public static function verify(string $nonce, string $action): bool
+        {
+            return self::$allow;
+        }
+    }
+
     final class Perms
     {
         private static bool $allow = true;


### PR DESCRIPTION
## Summary
- add a canonical Responses helper with ok/error utilities and simplify the optional nonce checker
- update REST controllers to use the shared helpers without changing response shapes
- cover the helpers with dedicated unit tests and refresh endpoint smoke checks

## Testing
- composer phpcs
- composer phpstan
- composer test


------
https://chatgpt.com/codex/tasks/task_e_68db2e05dfec8323a0e9dff8e153be69