### PR TITLE
feat(p1): endpoint REST de ingesta GLB (stub) + tests

### DIFF
--- a/plugins/g3d-models-manager/plugin.php
+++ b/plugins/g3d-models-manager/plugin.php
@@ -23,5 +23,7 @@ add_action('init', static function (): void {
 
 add_action('rest_api_init', static function (): void {
     $service = new \G3D\ModelsManager\Service\GlbIngestionService();
+
+    (new \G3D\ModelsManager\Api\GlbIngestController())->registerRoutes();
     (new \G3D\ModelsManager\Api\IngestionController($service))->registerRoutes();
 });

--- a/plugins/g3d-models-manager/src/Api/GlbIngestController.php
+++ b/plugins/g3d-models-manager/src/Api/GlbIngestController.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\ModelsManager\Api;
+
+use G3D\ModelsManager\Rbac\Capabilities;
+use G3D\VendorBase\Rest\Responses;
+use G3D\VendorBase\Rest\Security;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class GlbIngestController
+{
+    public function registerRoutes(): void
+    {
+        \register_rest_route(
+            'g3d/v1',
+            '/glb-ingest',
+            [
+                'methods'             => 'POST',
+                'callback'            => [$this, 'handle'],
+                'permission_callback' => static fn (): bool =>
+                    \function_exists('current_user_can')
+                        ? \current_user_can(Capabilities::CAP_RUN_VALIDATOR)
+                        : true,
+            ]
+        );
+    }
+
+    /**
+     * @return WP_REST_Response|WP_Error
+     */
+    public function handle(WP_REST_Request $req)
+    {
+        $nonce = Security::checkOptionalNonce($req);
+        if ($nonce instanceof WP_Error) {
+            // TODO(doc §auth): confirmar si la validación de nonce debe bloquear la petición.
+        }
+
+        $payload = $req->get_json_params();
+        if (!\is_array($payload)) {
+            $payload = [];
+        }
+
+        /** @var array{
+         *     binding: array<string, mixed>,
+         *     validation: array{
+         *         ok: bool,
+         *         missing: list<string>,
+         *         type: list<array{field:string, expected:string}>
+         *     }
+         * } $response
+         */
+        $response = Responses::ok([
+            'binding' => [
+                'file_hash'       => 'stub:sha256:deadbeef',
+                'filesize_bytes'  => 123456,
+                'draco_enabled'   => false,
+                'bounding_box'    => [
+                    'min' => [0.0, 0.0, 0.0],
+                    'max' => [10.0, 5.0, 2.0],
+                ],
+                'piece_type'          => 'FRAME',
+                'slots_detectados'    => ['Frame_Anchor', 'Socket_Cage'],
+                'anchors_present'     => ['Frame_Anchor', 'Temple_L_Anchor', 'Temple_R_Anchor'],
+                'props'               => [
+                    'socket_w_mm' => 45,
+                    'socket_h_mm' => 35,
+                    'variant'     => 'rx-classic',
+                ],
+                'object_name'         => 'frame_MAIN',
+                'object_name_pattern' => 'frame_*',
+                'model_code'          => 'mdl:rx-2025',
+            ],
+            'validation' => [
+                'ok'      => true,
+                'missing' => [],
+                'type'    => [],
+            ],
+        ]);
+
+        return new WP_REST_Response($response, 200);
+    }
+}

--- a/plugins/g3d-models-manager/src/Rbac/Capabilities.php
+++ b/plugins/g3d-models-manager/src/Rbac/Capabilities.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\ModelsManager\Rbac;
+
+final class Capabilities
+{
+    /**
+     * TODO(doc §auth): revisar centralización de capabilities.
+     */
+    public const CAP_RUN_VALIDATOR = 'g3d_run_validator';
+}

--- a/plugins/g3d-models-manager/tests/Api/GlbIngestControllerTest.php
+++ b/plugins/g3d-models-manager/tests/Api/GlbIngestControllerTest.php
@@ -2,53 +2,56 @@
 
 declare(strict_types=1);
 
-namespace G3D\ModelsManager\Tests\Api;
+namespace {
+    require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
+}
 
-use G3D\ModelsManager\Api\GlbIngestController;
-use PHPUnit\Framework\TestCase;
-use WP_REST_Request;
-use WP_REST_Response;
+namespace G3D\ModelsManager\Tests\Api {
 
-require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
+    use G3D\ModelsManager\Api\GlbIngestController;
+    use PHPUnit\Framework\TestCase;
+    use WP_REST_Request;
+    use WP_REST_Response;
 
-final class GlbIngestControllerTest extends TestCase
-{
-    public function testHandleReturnsOkWithBindingAndValidation(): void
+    final class GlbIngestControllerTest extends TestCase
     {
-        $controller = new GlbIngestController();
-        $request    = new WP_REST_Request('POST', '/g3d/v1/glb-ingest');
-        $request->set_header('Content-Type', 'application/json');
-        $request->set_body((string) json_encode(['fake' => true]));
+        public function testHandleReturnsOkWithBindingAndValidation(): void
+        {
+            $controller = new GlbIngestController();
+            $request    = new WP_REST_Request('POST', '/g3d/v1/glb-ingest');
+            $request->set_header('Content-Type', 'application/json');
+            $request->set_body((string) json_encode(['fake' => true]));
 
-        $response = $controller->handle($request);
+            $response = $controller->handle($request);
 
-        self::assertInstanceOf(WP_REST_Response::class, $response);
-        self::assertSame(200, $response->get_status());
+            self::assertInstanceOf(WP_REST_Response::class, $response);
+            self::assertSame(200, $response->get_status());
 
-        $data = $response->get_data();
-        self::assertIsArray($data);
-        self::assertArrayHasKey('ok', $data);
-        self::assertTrue($data['ok']);
-        self::assertArrayHasKey('binding', $data);
-        self::assertIsArray($data['binding']);
-        self::assertArrayHasKey('validation', $data);
-        self::assertIsArray($data['validation']);
+            $data = $response->get_data();
+            self::assertIsArray($data);
+            self::assertArrayHasKey('ok', $data);
+            self::assertTrue($data['ok']);
+            self::assertArrayHasKey('binding', $data);
+            self::assertIsArray($data['binding']);
+            self::assertArrayHasKey('validation', $data);
+            self::assertIsArray($data['validation']);
 
-        $binding = $data['binding'];
-        self::assertArrayHasKey('file_hash', $binding);
-        self::assertArrayHasKey('filesize_bytes', $binding);
-        self::assertArrayHasKey('draco_enabled', $binding);
-        self::assertArrayHasKey('bounding_box', $binding);
-        self::assertArrayHasKey('slots_detectados', $binding);
-        self::assertArrayHasKey('anchors_present', $binding);
-        self::assertArrayHasKey('props', $binding);
+            $binding = $data['binding'];
+            self::assertArrayHasKey('file_hash', $binding);
+            self::assertArrayHasKey('filesize_bytes', $binding);
+            self::assertArrayHasKey('draco_enabled', $binding);
+            self::assertArrayHasKey('bounding_box', $binding);
+            self::assertArrayHasKey('slots_detectados', $binding);
+            self::assertArrayHasKey('anchors_present', $binding);
+            self::assertArrayHasKey('props', $binding);
 
-        $validation = $data['validation'];
-        self::assertArrayHasKey('ok', $validation);
-        self::assertIsBool($validation['ok']);
-        self::assertArrayHasKey('missing', $validation);
-        self::assertIsArray($validation['missing']);
-        self::assertArrayHasKey('type', $validation);
-        self::assertIsArray($validation['type']);
+            $validation = $data['validation'];
+            self::assertArrayHasKey('ok', $validation);
+            self::assertIsBool($validation['ok']);
+            self::assertArrayHasKey('missing', $validation);
+            self::assertIsArray($validation['missing']);
+            self::assertArrayHasKey('type', $validation);
+            self::assertIsArray($validation['type']);
+        }
     }
 }

--- a/plugins/g3d-models-manager/tests/Api/GlbIngestControllerTest.php
+++ b/plugins/g3d-models-manager/tests/Api/GlbIngestControllerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\ModelsManager\Tests\Api;
+
+use G3D\ModelsManager\Api\GlbIngestController;
+use PHPUnit\Framework\TestCase;
+use WP_REST_Request;
+use WP_REST_Response;
+
+require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
+
+final class GlbIngestControllerTest extends TestCase
+{
+    public function testHandleReturnsOkWithBindingAndValidation(): void
+    {
+        $controller = new GlbIngestController();
+        $request    = new WP_REST_Request('POST', '/g3d/v1/glb-ingest');
+        $request->set_header('Content-Type', 'application/json');
+        $request->set_body((string) json_encode(['fake' => true]));
+
+        $response = $controller->handle($request);
+
+        self::assertInstanceOf(WP_REST_Response::class, $response);
+        self::assertSame(200, $response->get_status());
+
+        $data = $response->get_data();
+        self::assertIsArray($data);
+        self::assertArrayHasKey('ok', $data);
+        self::assertTrue($data['ok']);
+        self::assertArrayHasKey('binding', $data);
+        self::assertIsArray($data['binding']);
+        self::assertArrayHasKey('validation', $data);
+        self::assertIsArray($data['validation']);
+
+        $binding = $data['binding'];
+        self::assertArrayHasKey('file_hash', $binding);
+        self::assertArrayHasKey('filesize_bytes', $binding);
+        self::assertArrayHasKey('draco_enabled', $binding);
+        self::assertArrayHasKey('bounding_box', $binding);
+        self::assertArrayHasKey('slots_detectados', $binding);
+        self::assertArrayHasKey('anchors_present', $binding);
+        self::assertArrayHasKey('props', $binding);
+
+        $validation = $data['validation'];
+        self::assertArrayHasKey('ok', $validation);
+        self::assertIsBool($validation['ok']);
+        self::assertArrayHasKey('missing', $validation);
+        self::assertIsArray($validation['missing']);
+        self::assertArrayHasKey('type', $validation);
+        self::assertIsArray($validation['type']);
+    }
+}

--- a/plugins/g3d-models-manager/tests/bootstrap.php
+++ b/plugins/g3d-models-manager/tests/bootstrap.php
@@ -3,7 +3,34 @@
 declare(strict_types=1);
 
 namespace {
-    require __DIR__ . '/../vendor/autoload.php';
+    $vendorBaseBootstrap = __DIR__ . '/../../g3d-vendor-base-helper/tests/bootstrap.php';
+    if (is_file($vendorBaseBootstrap)) {
+        require_once $vendorBaseBootstrap;
+    }
+
+    $autoload = __DIR__ . '/../vendor/autoload.php';
+    if (is_file($autoload)) {
+        require $autoload;
+    }
+
+    $rootAutoload = __DIR__ . '/../../vendor/autoload.php';
+    if (is_file($rootAutoload)) {
+        require $rootAutoload;
+    }
+
+    spl_autoload_register(static function (string $class): void {
+        if (!str_starts_with($class, 'G3D\\ModelsManager\\')) {
+            return;
+        }
+
+        $relative     = substr($class, strlen('G3D\\ModelsManager\\'));
+        $relativePath = str_replace('\\', '/', $relative);
+        $file         = __DIR__ . '/../src/' . $relativePath . '.php';
+
+        if (is_file($file)) {
+            require_once $file;
+        }
+    });
 
     if (!function_exists('register_rest_route')) {
         function register_rest_route(string $namespace, string $route, array $args): void
@@ -136,23 +163,25 @@ namespace {
 }
 
 namespace Test_Env {
-    final class Perms
-    {
-        private static bool $allowAll = false;
-
-        public static function allows(string $cap): bool
+    if (!class_exists(Perms::class)) {
+        final class Perms
         {
-            return self::$allowAll;
-        }
+            private static bool $allowAll = false;
 
-        public static function allowAll(): void
-        {
-            self::$allowAll = true;
-        }
+            public static function allows(string $cap): bool
+            {
+                return self::$allowAll;
+            }
 
-        public static function denyAll(): void
-        {
-            self::$allowAll = false;
+            public static function allowAll(): void
+            {
+                self::$allowAll = true;
+            }
+
+            public static function denyAll(): void
+            {
+                self::$allowAll = false;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add GlbIngestController to expose the stubbed POST /g3d/v1/glb-ingest endpoint using the validator capability and vendor security helpers
- register the stub controller alongside existing ingestion routes and provide a local Capabilities constant for the plugin
- extend the plugin test bootstrap with vendor-base wiring/autoloading and cover the stub endpoint with a REST test

## Testing
- composer phpcs
- composer phpstan
- vendor/bin/phpunit --configuration plugins/g3d-models-manager/phpunit.xml.dist
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68db31059f04832387c66d5b626d47ff