### PR TITLE
chore(p5): unifica logger de auditoría con registry + tests (UI & REST)

### DIFF
--- a/plugins/g3d-admin-ops/src/Admin/Menu.php
+++ b/plugins/g3d-admin-ops/src/Admin/Menu.php
@@ -142,7 +142,7 @@ final class Menu
         $this->renderPlaceholder('G3D Admin & Ops', 'Plugin5 §5');
     }
 
-    private function renderAuditTrail(): void
+    public function renderAuditTrail(): void
     {
         if (!$this->guard->can(Capabilities::CAP_MANAGE_PUBLICATION)) {
             echo '<div class="wrap">';

--- a/plugins/g3d-admin-ops/src/Api/AuditWriteController.php
+++ b/plugins/g3d-admin-ops/src/Api/AuditWriteController.php
@@ -74,6 +74,6 @@ final class AuditWriteController
             return new WP_REST_Response($err, 400);
         }
 
-        return new WP_REST_Response(Responses::ok(), 201);
+        return new WP_REST_Response(Responses::ok(['saved' => true]), 201);
     }
 }

--- a/plugins/g3d-admin-ops/src/Plugin.php
+++ b/plugins/g3d-admin-ops/src/Plugin.php
@@ -7,6 +7,7 @@ namespace G3D\AdminOps;
 use G3D\AdminOps\Admin\Menu;
 use G3D\AdminOps\Audit\InMemoryEditorialActionLogger;
 use G3D\AdminOps\Rbac\CapabilityGuard;
+use G3D\AdminOps\Services\Registry;
 
 final class Plugin
 {
@@ -19,6 +20,7 @@ final class Plugin
     public function __construct()
     {
         $this->auditLogger = new InMemoryEditorialActionLogger();
+        Registry::instance()->set(Registry::S_AUDIT_LOGGER, $this->auditLogger);
         $this->guard = new CapabilityGuard();
         $this->menu = new Menu($this->guard, $this->auditLogger);
     }

--- a/plugins/g3d-admin-ops/src/Services/Registry.php
+++ b/plugins/g3d-admin-ops/src/Services/Registry.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\AdminOps\Services;
+
+/**
+ * Registro sencillo de servicios para compartir instancias entre UI y REST.
+ */
+final class Registry
+{
+    public const S_AUDIT_LOGGER = 'audit_logger';
+
+    /**
+     * @var array<string, object>
+     */
+    private array $services = [];
+
+    private static ?self $instance = null;
+
+    private function __construct()
+    {
+    }
+
+    public static function instance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function set(string $id, object $service): void
+    {
+        $this->services[$id] = $service;
+    }
+
+    public function get(string $id): ?object
+    {
+        return $this->services[$id] ?? null;
+    }
+}

--- a/plugins/g3d-admin-ops/tests/Api/AuditWriteControllerTest.php
+++ b/plugins/g3d-admin-ops/tests/Api/AuditWriteControllerTest.php
@@ -39,7 +39,10 @@ namespace G3D\AdminOps\Tests\Api {
 
             self::assertInstanceOf(WP_REST_Response::class, $response);
             self::assertSame(201, $response->get_status());
-            self::assertSame(['ok' => true], $response->get_data());
+            self::assertSame([
+                'ok'    => true,
+                'saved' => true,
+            ], $response->get_data());
 
             $events = $logger->getEvents();
             self::assertCount(1, $events);

--- a/plugins/g3d-admin-ops/tests/Integration/AuditSharedLoggerTest.php
+++ b/plugins/g3d-admin-ops/tests/Integration/AuditSharedLoggerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
+
+    if (!function_exists('esc_html__')) {
+        function esc_html__(string $text, string $domain = 'default'): string
+        {
+            return $text;
+        }
+    }
+
+    if (!function_exists('esc_html')) {
+        function esc_html(string $text): string
+        {
+            return $text;
+        }
+    }
+
+    if (!function_exists('__')) {
+        function __(string $text, string $domain = 'default'): string
+        {
+            return $text;
+        }
+    }
+}
+
+namespace G3D\AdminOps\Tests\Integration {
+
+    use G3D\AdminOps\Admin\Menu;
+    use G3D\AdminOps\Api\AuditReadController;
+    use G3D\AdminOps\Api\AuditWriteController;
+    use G3D\AdminOps\Audit\InMemoryEditorialActionLogger;
+    use G3D\AdminOps\Rbac\CapabilityGuard;
+    use G3D\AdminOps\Services\Registry;
+    use PHPUnit\Framework\TestCase;
+    use Test_Env\Perms;
+    use WP_REST_Request;
+    use WP_REST_Response;
+
+    final class AuditSharedLoggerTest extends TestCase
+    {
+        protected function tearDown(): void
+        {
+            Perms::denyAll();
+            parent::tearDown();
+        }
+
+        public function testPostCreatesEventVisibleOnGetAndUi(): void
+        {
+            Perms::allowAll();
+
+            $logger = new InMemoryEditorialActionLogger();
+            $registry = Registry::instance();
+            $registry->set(Registry::S_AUDIT_LOGGER, $logger);
+
+            $service = $registry->get(Registry::S_AUDIT_LOGGER);
+            self::assertInstanceOf(InMemoryEditorialActionLogger::class, $service);
+            self::assertSame($logger, $service);
+
+            $writeController = new AuditWriteController($service);
+            $readController = new AuditReadController($service);
+
+            $payload = [
+                'actor_id' => 'user:editor',
+                'action' => 'publish',
+                'context' => [
+                    'what' => 'prod:rx-1',
+                    'occurred_at' => '2025-09-29T00:00:00+00:00',
+                ],
+            ];
+
+            $postRequest = new WP_REST_Request('POST', '/g3d/v1/audit');
+            $postRequest->set_header('Content-Type', 'application/json');
+            $json = json_encode($payload);
+            self::assertIsString($json);
+            $postRequest->set_body($json);
+
+            $writeResponse = $writeController->handle($postRequest);
+            self::assertInstanceOf(WP_REST_Response::class, $writeResponse);
+            self::assertSame(201, $writeResponse->get_status());
+            self::assertSame([
+                'ok'    => true,
+                'saved' => true,
+            ], $writeResponse->get_data());
+
+            $getRequest = new WP_REST_Request('GET', '/g3d/v1/audit');
+            $readResponse = $readController->handle($getRequest);
+            self::assertInstanceOf(WP_REST_Response::class, $readResponse);
+            self::assertSame(200, $readResponse->get_status());
+
+            $data = $readResponse->get_data();
+            self::assertIsArray($data);
+            self::assertTrue($data['ok']);
+
+            $events = $data['events'] ?? [];
+            self::assertIsArray($events);
+            self::assertNotEmpty($events);
+
+            /**
+             * @var array{actor_id:string,action:string,what:string,occurred_at:string} $event
+             */
+            $event = $events[0];
+            self::assertSame('user:editor', $event['actor_id']);
+            self::assertSame('publish', $event['action']);
+            self::assertSame('prod:rx-1', $event['what']);
+
+            $menu = new Menu(new CapabilityGuard(), $service);
+            ob_start();
+            $menu->renderAuditTrail();
+            $html = (string) ob_get_clean();
+
+            self::assertStringContainsString('Versiones & Auditoría', $html);
+            self::assertStringContainsString('prod:rx-1', $html);
+        }
+    }
+}

--- a/plugins/g3d-admin-ops/tests/Routes/AuditRouteRegistrationTest.php
+++ b/plugins/g3d-admin-ops/tests/Routes/AuditRouteRegistrationTest.php
@@ -32,7 +32,6 @@ final class AuditRouteRegistrationTest extends TestCase
     public function testAuditWriteRouteRegistered(): void
     {
         \do_action('rest_api_init');
-
         self::assertTrue(self::routeExists('g3d/v1', '/audit', 'POST'));
     }
 
@@ -44,10 +43,13 @@ final class AuditRouteRegistrationTest extends TestCase
         $routes = $GLOBALS['g3d_tests_registered_rest_routes'];
 
         foreach ($routes as $r) {
-            if ($r['namespace'] === $ns && $r['route'] === $route) {
-                $methods = $r['args']['methods'] ?? '';
+            if ($r['namespace'] !== $ns || $r['route'] !== $route) {
+                continue;
+            }
 
-                return \is_string($methods) ? \str_contains($methods, $method) : false;
+            $methods = $r['args']['methods'] ?? '';
+            if (\is_string($methods) && \str_contains($methods, $method)) {
+                return true;
             }
         }
 


### PR DESCRIPTION
## Summary
- agrega un Registry de servicios para compartir la instancia de InMemoryEditorialActionLogger
- conecta el bootstrap del plugin (UI + REST) al registry y devuelve `saved: true` en el POST de auditoría
- suma tests que validan que el logger es compartido en REST y en la pantalla de Versiones & Auditoría

## Testing
- composer phpstan
- vendor/bin/phpunit --configuration plugins/g3d-admin-ops/phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68db3d4d28a88323baec83adc976b405