### PR TITLE
feat(p4): JS del Wizard Modal (open/close + focus trap) y enqueue solo en su página

### DIFF
--- a/plugins/gafas3d-wizard-modal/assets/css/modal.css
+++ b/plugins/gafas3d-wizard-modal/assets/css/modal.css
@@ -1,0 +1,33 @@
+[data-g3d-wizard-modal-overlay] {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(0, 0, 0, 0.5);
+    padding: 2rem;
+    box-sizing: border-box;
+    z-index: 1000;
+}
+
+[hidden] {
+    display: none !important;
+}
+
+.g3d-wizard-modal {
+    background-color: #fff;
+    max-width: 960px;
+    width: 100%;
+    max-height: 90vh;
+    overflow: auto;
+    border-radius: 8px;
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
+    outline: none;
+    padding: 2rem;
+}
+
+.g3d-wizard-modal__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}

--- a/plugins/gafas3d-wizard-modal/assets/js/modal.js
+++ b/plugins/gafas3d-wizard-modal/assets/js/modal.js
@@ -1,0 +1,123 @@
+(() => {
+    const openButton = document.querySelector('[data-g3d-wizard-modal-open]');
+    const overlay = document.querySelector('[data-g3d-wizard-modal-overlay]');
+    const modal = overlay ? overlay.querySelector('.g3d-wizard-modal') : null;
+    const closeButton = overlay ? overlay.querySelector('[data-g3d-wizard-modal-close]') : null;
+    const focusGuards = overlay ? overlay.querySelectorAll('[data-g3d-wizard-focus-guard]') : [];
+
+    if (!openButton || !overlay || !modal || !closeButton) {
+        return;
+    }
+
+    let lastFocusedElement = null;
+    let isOpen = false;
+
+    const focusableSelectors = [
+        'a[href]',
+        'button:not([disabled])',
+        'textarea:not([disabled])',
+        'input:not([disabled])',
+        'select:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])'
+    ];
+
+    const getFocusableElements = () => {
+        const elements = modal.querySelectorAll(focusableSelectors.join(','));
+
+        return Array.from(elements).filter((element) => {
+            const guard = element.getAttribute('data-g3d-wizard-focus-guard');
+
+            return guard === null;
+        });
+    };
+
+    const focusFirstElement = () => {
+        const focusable = getFocusableElements();
+
+        if (focusable.length > 0) {
+            focusable[0].focus();
+
+            return;
+        }
+
+        modal.focus();
+    };
+
+    const focusLastElement = () => {
+        const focusable = getFocusableElements();
+
+        if (focusable.length > 0) {
+            focusable[focusable.length - 1].focus();
+
+            return;
+        }
+
+        modal.focus();
+    };
+
+    const closeModal = () => {
+        if (!isOpen) {
+            return;
+        }
+
+        overlay.setAttribute('hidden', 'hidden');
+        overlay.removeAttribute('data-g3d-wizard-modal-open');
+        document.removeEventListener('keydown', handleKeydown);
+        isOpen = false;
+
+        if (lastFocusedElement instanceof HTMLElement) {
+            lastFocusedElement.focus();
+        }
+    };
+
+    const openModal = () => {
+        if (isOpen) {
+            return;
+        }
+
+        lastFocusedElement = document.activeElement;
+        overlay.removeAttribute('hidden');
+        overlay.setAttribute('data-g3d-wizard-modal-open', 'true');
+        document.addEventListener('keydown', handleKeydown);
+        isOpen = true;
+        focusFirstElement();
+    };
+
+    const handleKeydown = (event) => {
+        if (!isOpen) {
+            return;
+        }
+
+        if (event.key === 'Escape' || event.key === 'Esc') {
+            event.preventDefault();
+            closeModal();
+        }
+    };
+
+    const handleFocusGuard = (event) => {
+        const guard = event.currentTarget;
+
+        if (!(guard instanceof HTMLElement)) {
+            return;
+        }
+
+        if (guard.dataset.g3dWizardFocusGuard === 'start') {
+            focusLastElement();
+        } else {
+            focusFirstElement();
+        }
+    };
+
+    openButton.addEventListener('click', openModal);
+    closeButton.addEventListener('click', closeModal);
+
+    overlay.addEventListener('click', (event) => {
+        if (event.target === overlay) {
+            closeModal();
+        }
+    });
+
+    focusGuards.forEach((guard) => {
+        guard.addEventListener('focus', handleFocusGuard);
+    });
+})();

--- a/plugins/gafas3d-wizard-modal/plugin.php
+++ b/plugins/gafas3d-wizard-modal/plugin.php
@@ -48,7 +48,7 @@ add_action('admin_menu', static function (): void {
 });
 
 add_action('plugins_loaded', static function (): void {
-    (new AdminAssets())->register();
+    (new AdminAssets(__FILE__))->register();
 });
 
 add_action('wp_enqueue_scripts', [Assets::class, 'register']);

--- a/plugins/gafas3d-wizard-modal/src/Admin/Assets.php
+++ b/plugins/gafas3d-wizard-modal/src/Admin/Assets.php
@@ -5,197 +5,67 @@ declare(strict_types=1);
 namespace Gafas3d\WizardModal\Admin;
 
 use function add_action;
-use function is_string;
-use function wp_add_inline_script;
-use function wp_add_inline_style;
+use function file_exists;
+use function filemtime;
+use function plugin_dir_path;
+use function plugins_url;
 use function wp_enqueue_script;
 use function wp_enqueue_style;
-use function wp_register_script;
-use function wp_register_style;
-use function wp_json_encode;
 
 final class Assets
 {
-    private string $handle = 'g3d-wizard-modal-admin';
+    private string $pluginFile;
+
+    public function __construct(string $pluginFile)
+    {
+        $this->pluginFile = $pluginFile;
+    }
 
     public function register(): void
     {
-        add_action('admin_enqueue_scripts', function (): void {
-            $page = $_GET['page'] ?? null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
-            if (!is_string($page) || $page !== Page::MENU_SLUG) {
-                return;
-            }
-
-            $this->enqueueStyle();
-            $this->enqueueScript();
-        });
+        add_action('admin_enqueue_scripts', [$this, 'enqueue'], 10, 1);
     }
 
-    private function enqueueStyle(): void
+    public function enqueue(string $hook): void
     {
-        wp_register_style($this->handle, false, [], null);
-        wp_enqueue_style($this->handle);
-        wp_add_inline_style($this->handle, $this->style());
-    }
+        if ($hook !== 'toplevel_page_' . Page::MENU_SLUG) {
+            return;
+        }
 
-    private function enqueueScript(): void
-    {
-        wp_register_script($this->handle, '', [], null, true);
-        wp_enqueue_script($this->handle);
-        wp_add_inline_script($this->handle, $this->script());
-    }
+        $pluginDir = plugin_dir_path($this->pluginFile);
 
-    private function style(): string
-    {
-        return <<<CSS
-.g3d-wizard-modal__overlay[hidden] {
-    display: none;
-}
+        $jsPath = $pluginDir . 'assets/js/modal.js';
+        $cssPath = $pluginDir . 'assets/css/modal.css';
 
-.g3d-wizard-modal__overlay {
-    position: fixed;
-    inset: 0;
-    display: flex;
-    align-items: flex-start;
-    justify-content: center;
-    padding: 5vh 2rem;
-    background: rgba(0, 0, 0, 0.55);
-    overflow-y: auto;
-    z-index: 100000;
-}
+        $jsVersion = $this->resolveVersion($jsPath);
+        $cssVersion = $this->resolveVersion($cssPath);
 
-.g3d-wizard-modal {
-    width: 100%;
-    max-width: 960px;
-    margin: 5vh auto;
-    background: #fff;
-    border-radius: 12px;
-    box-shadow: 0 24px 48px rgba(0, 0, 0, 0.25);
-}
-
-.g3d-wizard-modal__content {
-    padding: 24px;
-}
-
-.g3d-wizard-modal__header,
-.g3d-wizard-modal__footer {
-    padding: 0 24px 24px;
-}
-CSS;
-    }
-
-    private function script(): string
-    {
-        $focusableSelector = wp_json_encode(
-            'a[href], button:not([disabled]), textarea, input, select, '
-            . '[tabindex]:not([tabindex="-1"])'
+        wp_enqueue_script(
+            'g3d-wizard-modal-js',
+            plugins_url('assets/js/modal.js', $this->pluginFile),
+            [],
+            $jsVersion,
+            true
         );
 
-        return <<<JS
-(function () {
-    const overlay = document.querySelector('[data-g3d-wizard-modal-overlay]');
-    if (!overlay) {
-        return;
+        wp_enqueue_style(
+            'g3d-wizard-modal-css',
+            plugins_url('assets/css/modal.css', $this->pluginFile),
+            [],
+            $cssVersion
+        );
     }
 
-    const modal = overlay.querySelector('.g3d-wizard-modal');
-    if (!modal) {
-        return;
-    }
+    private function resolveVersion(string $path): string
+    {
+        if (file_exists($path)) {
+            $timestamp = filemtime($path);
 
-    const openers = document.querySelectorAll('[data-g3d-wizard-modal-open]');
-    const closers = overlay.querySelectorAll('[data-g3d-wizard-modal-close]');
-    const focusGuards = overlay.querySelectorAll('[data-g3d-wizard-focus-guard]');
-    const focusableSelector = {$focusableSelector};
-    let lastTrigger = null;
-
-    function getFocusableElements() {
-        return Array.from(modal.querySelectorAll(focusableSelector))
-            .filter(function (element) {
-                return !element.hasAttribute('disabled')
-                    && element.getAttribute('aria-hidden') !== 'true'
-                    && element.offsetParent !== null;
-            });
-    }
-
-    function focusInitialElement() {
-        const focusable = getFocusableElements();
-        if (focusable.length > 0) {
-            focusable[0].focus();
-            return;
+            if ($timestamp !== false) {
+                return (string) $timestamp;
+            }
         }
 
-        modal.focus();
-    }
-
-    function onKeydown(event) {
-        if (event.key !== 'Escape' && event.key !== 'Esc') {
-            return;
-        }
-
-        if (overlay.hasAttribute('hidden')) {
-            return;
-        }
-
-        event.preventDefault();
-        closeModal();
-    }
-
-    function openModal(trigger) {
-        lastTrigger = trigger || document.activeElement;
-        overlay.removeAttribute('hidden');
-        focusInitialElement();
-        document.addEventListener('keydown', onKeydown);
-    }
-
-    function closeModal() {
-        overlay.setAttribute('hidden', '');
-        document.removeEventListener('keydown', onKeydown);
-
-        if (lastTrigger && typeof lastTrigger.focus === 'function') {
-            lastTrigger.focus();
-        }
-    }
-
-    openers.forEach(function (opener) {
-        opener.addEventListener('click', function (event) {
-            event.preventDefault();
-            openModal(opener);
-        });
-    });
-
-    closers.forEach(function (closer) {
-        closer.addEventListener('click', function (event) {
-            event.preventDefault();
-            closeModal();
-        });
-    });
-
-    focusGuards.forEach(function (guard) {
-        guard.addEventListener('focus', function () {
-            if (overlay.hasAttribute('hidden')) {
-                return;
-            }
-
-            const focusable = getFocusableElements();
-
-            if (focusable.length === 0) {
-                modal.focus();
-                return;
-            }
-
-            if (guard.dataset.g3dWizardFocusGuard === 'start') {
-                focusable[focusable.length - 1].focus();
-                return;
-            }
-
-            if (guard.dataset.g3dWizardFocusGuard === 'end') {
-                focusable[0].focus();
-            }
-        });
-    });
-})();
-JS;
+        return '1.0.0';
     }
 }

--- a/plugins/gafas3d-wizard-modal/tests/Admin/AssetsTest.php
+++ b/plugins/gafas3d-wizard-modal/tests/Admin/AssetsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gafas3d\WizardModal\Tests\Admin;
+
+use Gafas3d\WizardModal\Admin\Assets;
+use PHPUnit\Framework\TestCase;
+
+use function do_action;
+
+final class AssetsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['g3d_tests_wp_actions']['admin_enqueue_scripts'] = [];
+        $GLOBALS['g3d_wizard_modal_enqueued_scripts'] = [];
+        $GLOBALS['g3d_wizard_modal_enqueued_styles'] = [];
+    }
+
+    public function testEnqueuesAssetsOnWizardPage(): void
+    {
+        $assets = new Assets(dirname(__DIR__, 2) . '/plugin.php');
+        $assets->register();
+
+        do_action('admin_enqueue_scripts', 'toplevel_page_g3d-wizard');
+
+        self::assertArrayHasKey('g3d-wizard-modal-js', $GLOBALS['g3d_wizard_modal_enqueued_scripts']);
+        self::assertArrayHasKey('g3d-wizard-modal-css', $GLOBALS['g3d_wizard_modal_enqueued_styles']);
+    }
+
+    public function testDoesNotEnqueueAssetsOnOtherPages(): void
+    {
+        $assets = new Assets(dirname(__DIR__, 2) . '/plugin.php');
+        $assets->register();
+
+        do_action('admin_enqueue_scripts', 'toplevel_page_other');
+
+        self::assertSame([], $GLOBALS['g3d_wizard_modal_enqueued_scripts']);
+        self::assertSame([], $GLOBALS['g3d_wizard_modal_enqueued_styles']);
+    }
+}

--- a/plugins/gafas3d-wizard-modal/tests/bootstrap.php
+++ b/plugins/gafas3d-wizard-modal/tests/bootstrap.php
@@ -55,3 +55,81 @@ if (!function_exists('esc_html__')) {
         return $text;
     }
 }
+
+if (!function_exists('plugin_dir_path')) {
+    function plugin_dir_path(string $file): string
+    {
+        return rtrim(dirname($file), '\\/') . '/';
+    }
+}
+
+if (!function_exists('plugins_url')) {
+    function plugins_url(string $path = '', string $pluginFile = ''): string
+    {
+        $base = 'https://example.com/wp-content/plugins';
+
+        if ($pluginFile !== '') {
+            $base .= '/' . basename(dirname($pluginFile));
+        }
+
+        if ($path !== '') {
+            $path = '/' . ltrim($path, '/');
+        }
+
+        return $base . $path;
+    }
+}
+
+if (!isset($GLOBALS['g3d_wizard_modal_enqueued_scripts'])) {
+    /**
+     * @var array<string, array{src:string,deps:array<int, string>,ver:string|bool,in_footer:bool}> $GLOBALS['g3d_wizard_modal_enqueued_scripts']
+     */
+    $GLOBALS['g3d_wizard_modal_enqueued_scripts'] = [];
+}
+
+if (!isset($GLOBALS['g3d_wizard_modal_enqueued_styles'])) {
+    /**
+     * @var array<string, array{src:string,deps:array<int, string>,ver:string|bool,media:string}> $GLOBALS['g3d_wizard_modal_enqueued_styles']
+     */
+    $GLOBALS['g3d_wizard_modal_enqueued_styles'] = [];
+}
+
+if (!function_exists('wp_enqueue_script')) {
+    /**
+     * @param array<int, string> $deps
+     */
+    function wp_enqueue_script(
+        string $handle,
+        string $src = '',
+        array $deps = [],
+        string|bool $ver = false,
+        bool $inFooter = false
+    ): void {
+        $GLOBALS['g3d_wizard_modal_enqueued_scripts'][$handle] = [
+            'src' => $src,
+            'deps' => $deps,
+            'ver' => $ver,
+            'in_footer' => $inFooter,
+        ];
+    }
+}
+
+if (!function_exists('wp_enqueue_style')) {
+    /**
+     * @param array<int, string> $deps
+     */
+    function wp_enqueue_style(
+        string $handle,
+        string $src = '',
+        array $deps = [],
+        string|bool $ver = false,
+        string $media = 'all'
+    ): void {
+        $GLOBALS['g3d_wizard_modal_enqueued_styles'][$handle] = [
+            'src' => $src,
+            'deps' => $deps,
+            'ver' => $ver,
+            'media' => $media,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- agrega Assets Admin para cargar el JS/CSS del wizard únicamente en `toplevel_page_g3d-wizard`
- implementa `modal.js` con apertura/cierre, overlay, tecla Escape y focus trap usando los guards existentes
- añade `modal.css` con estilos mínimos del overlay y modal, y pruebas que validan el enqueue condicional

## Checklist
- [x] Modal assets se cargan solo en `toplevel_page_g3d-wizard`
- [x] Modal abre/cierra, responde a Escape y overlay, mantiene el foco dentro
- [x] composer test
- [x] ./vendor/bin/phpunit --configuration plugins/gafas3d-wizard-modal/phpunit.xml.dist
- [x] composer phpstan

------
https://chatgpt.com/codex/tasks/task_e_68db42ae5d7083239d53e781bc79344e