### PR TITLE
feat(sec): nonce + capability en endpoints REST de Validate & Sign (+ tests)

### DIFF
--- a/plugins/g3d-validate-sign/src/Api/ValidateSignController.php
+++ b/plugins/g3d-validate-sign/src/Api/ValidateSignController.php
@@ -9,14 +9,25 @@ use DateTimeZone;
 use G3D\ValidateSign\Crypto\Signer;
 use G3D\ValidateSign\Domain\Expiry;
 use G3D\ValidateSign\Validation\RequestValidator;
+use G3D\VendorBase\Auth\RestPerms;
 use G3D\VendorBase\Rest\Responses;
 use G3D\VendorBase\Rest\Security;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 
+/**
+ * REST controller to sign SKU payloads.
+ *
+ * Requires the CAP_USE_API capability to access the REST endpoint.
+ */
 class ValidateSignController
 {
+    /**
+     * Capability required to consume the Validate & Sign REST API.
+     */
+    public const CAP_USE_API = 'g3d_validate_use_api';
+
     private RequestValidator $validator;
     private Signer $signer;
     private Expiry $expiry;
@@ -42,7 +53,9 @@ class ValidateSignController
             [
                 'methods' => 'POST',
                 'callback' => [$this, 'handle'],
-                'permission_callback' => '__return_true', // público según docs/plugin-3-g3d-validate-sign.md §2.
+                'permission_callback' => static function (WP_REST_Request $request): bool {
+                    return RestPerms::canUse(self::CAP_USE_API, $request);
+                },
             ]
         );
     }

--- a/plugins/g3d-validate-sign/src/Api/VerifyController.php
+++ b/plugins/g3d-validate-sign/src/Api/VerifyController.php
@@ -9,12 +9,19 @@ use DateTimeZone;
 use G3D\ValidateSign\Crypto\Verifier;
 use G3D\ValidateSign\Domain\Expiry;
 use G3D\ValidateSign\Validation\RequestValidator;
+use G3D\VendorBase\Auth\RestPerms;
 use G3D\VendorBase\Rest\Responses;
 use G3D\VendorBase\Rest\Security;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 
+/**
+ * REST controller to verify SKU signatures.
+ *
+ * Requires the ValidateSignController::CAP_USE_API capability to access the
+ * endpoint.
+ */
 class VerifyController
 {
     private RequestValidator $validator;
@@ -42,7 +49,9 @@ class VerifyController
             [
                 'methods' => 'POST',
                 'callback' => [$this, 'handle'],
-                'permission_callback' => '__return_true', // público según docs/plugin-3-g3d-validate-sign.md §2.
+                'permission_callback' => static function (WP_REST_Request $request): bool {
+                    return RestPerms::canUse(ValidateSignController::CAP_USE_API, $request);
+                },
             ]
         );
     }

--- a/plugins/g3d-validate-sign/tests/Api/PermissionsTest.php
+++ b/plugins/g3d-validate-sign/tests/Api/PermissionsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\ValidateSign\Tests\Api;
+
+use G3D\ValidateSign\Api\ValidateSignController;
+use G3D\ValidateSign\Api\VerifyController;
+use G3D\ValidateSign\Domain\Expiry;
+use G3D\ValidateSign\Validation\RequestValidator;
+use PHPUnit\Framework\TestCase;
+use Test_Env\Nonce;
+use Test_Env\Perms;
+use WP_REST_Request;
+
+final class PermissionsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Perms::allowAll();
+        Nonce::allow();
+        $GLOBALS['g3d_tests_registered_rest_routes'] = [];
+
+        $this->registerRoutes();
+    }
+
+    public function testValidateSignRouteRequiresNonceAndCapability(): void
+    {
+        $callback = $this->getPermissionCallback('/validate-sign');
+
+        $this->assertPermissionMatrix($callback, '/validate-sign');
+    }
+
+    public function testVerifyRouteRequiresNonceAndCapability(): void
+    {
+        $callback = $this->getPermissionCallback('/verify');
+
+        $this->assertPermissionMatrix($callback, '/verify');
+    }
+
+    /**
+     * @return callable
+     */
+    private function getPermissionCallback(string $route): callable
+    {
+        foreach ($GLOBALS['g3d_tests_registered_rest_routes'] as $registered) {
+            if ($registered['namespace'] === 'g3d/v1' && $registered['route'] === $route) {
+                self::assertArrayHasKey('permission_callback', $registered['args']);
+                self::assertIsCallable($registered['args']['permission_callback']);
+
+                return $registered['args']['permission_callback'];
+            }
+        }
+
+        self::fail('Route not registered: ' . $route);
+    }
+
+    private function assertPermissionMatrix(callable $callback, string $route): void
+    {
+        Perms::allowAll();
+        Nonce::allow();
+        $request = $this->createRequest($route, true);
+        self::assertTrue($callback($request));
+
+        Perms::denyAll();
+        Nonce::allow();
+        $request = $this->createRequest($route, true);
+        self::assertFalse($callback($request));
+
+        Perms::allowAll();
+        Nonce::allow();
+        $request = $this->createRequest($route, false);
+        self::assertFalse($callback($request));
+
+        Perms::denyAll();
+        Nonce::allow();
+        $request = $this->createRequest($route, false);
+        self::assertFalse($callback($request));
+    }
+
+    private function createRequest(string $route, bool $withNonce): WP_REST_Request
+    {
+        $request = new WP_REST_Request('POST', '/g3d/v1' . $route);
+
+        if ($withNonce) {
+            $request->set_header('X-WP-Nonce', 'ok');
+        }
+
+        return $request;
+    }
+
+    private function registerRoutes(): void
+    {
+        $validator = $this->createStub(RequestValidator::class);
+        $expiry = new Expiry();
+
+        $signer = $this->getMockBuilder(\G3D\ValidateSign\Crypto\Signer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $validateController = new ValidateSignController($validator, $signer, $expiry, 'private-key');
+        $validateController->registerRoutes();
+
+        $verifier = $this->getMockBuilder(\G3D\ValidateSign\Crypto\Verifier::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $verifyController = new VerifyController($validator, $verifier, $expiry, 'public-key');
+        $verifyController->registerRoutes();
+    }
+}

--- a/plugins/g3d-vendor-base-helper/src/Auth/RestPerms.php
+++ b/plugins/g3d-vendor-base-helper/src/Auth/RestPerms.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Auth;
+
+use WP_REST_Request;
+
+final class RestPerms
+{
+    public static function canUse(string $cap, ?WP_REST_Request $req = null): bool
+    {
+        $nonce = null;
+
+        if ($req !== null) {
+            $nonce = $req->get_header('X-WP-Nonce');
+
+            if ($nonce === null || $nonce === '') {
+                $nonce = $req->get_header('x-wp-nonce');
+            }
+        }
+
+        if (!is_string($nonce) || $nonce === '') {
+            return false;
+        }
+
+        if (!\wp_verify_nonce($nonce, 'wp_rest')) {
+            return false;
+        }
+
+        return \current_user_can($cap);
+    }
+}


### PR DESCRIPTION
## Summary
- add shared RestPerms helper to enforce nonce and capability checks for REST endpoints
- secure Validate & Sign routes behind the g3d_validate_use_api capability
- cover both endpoints with permission matrix tests for nonce/capability combinations

## Testing
- composer test
- composer phpstan

------
https://chatgpt.com/codex/tasks/task_e_68db457684bc8323bc41d8848a6bf368