### PR TITLE
feat(p4b): wizard modal REST config (rest_url + nonce) + fetch helper + tests

### DIFF
--- a/plugins/gafas3d-wizard-modal/assets/js/wizard-modal.js
+++ b/plugins/gafas3d-wizard-modal/assets/js/wizard-modal.js
@@ -3,6 +3,19 @@
 
   global.G3DWIZARD = global.G3DWIZARD || {};
 
+  global.G3DWIZARD.postJson = async function postJson(url, body) {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-WP-Nonce': (global.G3DWIZARD && global.G3DWIZARD.nonce) || '',
+      },
+      body: JSON.stringify(body || {}),
+    });
+
+    return res;
+  };
+
   if (global.console && typeof global.console.log === 'function') {
     global.console.log(global.G3DWIZARD.api);
   }

--- a/plugins/gafas3d-wizard-modal/src/Assets/Assets.php
+++ b/plugins/gafas3d-wizard-modal/src/Assets/Assets.php
@@ -6,7 +6,10 @@ namespace Gafas3d\WizardModal\Assets;
 
 use function add_action;
 use function dirname;
+use function get_locale;
 use function plugins_url;
+use function rest_url;
+use function wp_create_nonce;
 use function wp_enqueue_script;
 use function wp_enqueue_style;
 use function wp_localize_script;
@@ -52,9 +55,11 @@ final class Assets
             'G3DWIZARD',
             [
                 'api' => [
-                    'validateSign' => '/wp-json/g3d/v1/validate-sign',
-                    'verify' => '/wp-json/g3d/v1/verify',
+                    'validateSign' => rest_url('g3d/v1/validate-sign'),
+                    'verify' => rest_url('g3d/v1/verify'),
                 ],
+                'nonce' => wp_create_nonce('wp_rest'),
+                'locale' => get_locale(),
             ]
         );
 

--- a/plugins/gafas3d-wizard-modal/tests/Assets/AssetsTest.php
+++ b/plugins/gafas3d-wizard-modal/tests/Assets/AssetsTest.php
@@ -41,8 +41,13 @@ final class AssetsTest extends TestCase
         self::assertStringEndsWith('assets/css/wizard-modal.css', $registeredStyles[Assets::HANDLE_CSS]['src']);
 
         $localized = $GLOBALS['g3d_wizard_modal_localized_scripts'][Assets::HANDLE_JS]['G3DWIZARD'] ?? [];
-        self::assertSame('/wp-json/g3d/v1/validate-sign', $localized['api']['validateSign'] ?? null);
-        self::assertSame('/wp-json/g3d/v1/verify', $localized['api']['verify'] ?? null);
+        self::assertSame(
+            'http://example.test/wp-json/g3d/v1/validate-sign',
+            $localized['api']['validateSign'] ?? null
+        );
+        self::assertSame('http://example.test/wp-json/g3d/v1/verify', $localized['api']['verify'] ?? null);
+        self::assertSame('nonce-123', $localized['nonce'] ?? null);
+        self::assertSame('es_ES', $localized['locale'] ?? null);
 
         self::assertArrayHasKey(Assets::HANDLE_JS, $GLOBALS['g3d_wizard_modal_enqueued_scripts']);
         self::assertArrayHasKey(Assets::HANDLE_CSS, $GLOBALS['g3d_wizard_modal_enqueued_styles']);

--- a/plugins/gafas3d-wizard-modal/tests/Assets/HelperExposureTest.php
+++ b/plugins/gafas3d-wizard-modal/tests/Assets/HelperExposureTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gafas3d\WizardModal\Tests\Assets;
+
+use Gafas3d\WizardModal\Assets\Assets;
+use PHPUnit\Framework\TestCase;
+
+use function do_action;
+use function strpos;
+
+final class HelperExposureTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['g3d_tests_wp_actions']['wp_enqueue_scripts'] = [];
+        $GLOBALS['g3d_wizard_modal_registered_scripts'] = [];
+        $GLOBALS['g3d_wizard_modal_registered_styles'] = [];
+        $GLOBALS['g3d_wizard_modal_localized_scripts'] = [];
+        $GLOBALS['g3d_wizard_modal_enqueued_scripts'] = [];
+        $GLOBALS['g3d_wizard_modal_enqueued_styles'] = [];
+    }
+
+    public function testNonceAndApiUrlsAreExposed(): void
+    {
+        Assets::register();
+
+        do_action('wp_enqueue_scripts');
+
+        $localized = $GLOBALS['g3d_wizard_modal_localized_scripts'][Assets::HANDLE_JS]['G3DWIZARD'] ?? [];
+
+        self::assertArrayHasKey('nonce', $localized);
+        self::assertSame('nonce-123', $localized['nonce']);
+        self::assertSame(0, strpos($localized['api']['validateSign'] ?? '', 'http://example.test/wp-json/'));
+        self::assertSame(0, strpos($localized['api']['verify'] ?? '', 'http://example.test/wp-json/'));
+    }
+}

--- a/plugins/gafas3d-wizard-modal/tests/bootstrap.php
+++ b/plugins/gafas3d-wizard-modal/tests/bootstrap.php
@@ -80,6 +80,29 @@ if (!function_exists('plugins_url')) {
     }
 }
 
+if (!function_exists('rest_url')) {
+    function rest_url(string $path = ''): string
+    {
+        $base = 'http://example.test/wp-json/';
+
+        return rtrim($base, '/') . '/' . ltrim($path, '/');
+    }
+}
+
+if (!function_exists('wp_create_nonce')) {
+    function wp_create_nonce(string $action = 'wp_rest'): string
+    {
+        return 'nonce-123';
+    }
+}
+
+if (!function_exists('get_locale')) {
+    function get_locale(): string
+    {
+        return 'es_ES';
+    }
+}
+
 if (!isset($GLOBALS['g3d_wizard_modal_enqueued_scripts'])) {
     /**
      * @var array<string, array{src:string,deps:array<int, string>,ver:string|bool,in_footer:bool}> $GLOBALS['g3d_wizard_modal_enqueued_scripts']


### PR DESCRIPTION
## Summary
- update wizard asset registration to localize dynamic REST endpoints, locale, and nonce
- add a reusable postJson helper on the wizard modal script for authenticated POST requests
- extend bootstrap stubs and add tests that cover the localized configuration

## Testing
- composer test *(fails: vendor/bin/phpunit not found in container)*
- composer phpstan *(fails: vendor/bin/phpstan not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db4b53637c8323891ebe4d29f41262