### PR TITLE
feat(p3): alineación Validate/Verify con docs (TTL, prefijos, schemas, errores) + tests

### DIFF
--- a/plugins/g3d-validate-sign/src/Api/ValidateSignController.php
+++ b/plugins/g3d-validate-sign/src/Api/ValidateSignController.php
@@ -52,9 +52,9 @@ class ValidateSignController
         Expiry $expiry,
         string $privateKey
     ) {
-        $this->validator = $validator;
-        $this->signer = $signer;
-        $this->expiry = $expiry;
+        $this->validator  = $validator;
+        $this->signer     = $signer;
+        $this->expiry     = $expiry;
         $this->privateKey = $privateKey;
     }
 
@@ -64,9 +64,10 @@ class ValidateSignController
             'g3d/v1',
             '/validate-sign',
             [
-                'methods' => 'POST',
+                'methods'  => 'POST',
                 'callback' => [$this, 'handle'],
-                // público según docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md §2.1.
+                // público según docs/Capa 3 — Validación, Firma y Caducidad — Actualizada
+                // (slots Abiertos) — V2 (urls).md §2.1.
                 'permission_callback' => static fn (): bool => true,
             ]
         );
@@ -80,7 +81,7 @@ class ValidateSignController
         }
 
         $requestId = $this->generateRequestId();
-        $payload = $request->get_json_params();
+        $payload   = $request->get_json_params();
 
         if (!is_array($payload)) {
             $payload = [];
@@ -89,25 +90,25 @@ class ValidateSignController
         $validation = $this->validator->validate($payload);
 
         if (!empty($validation['missing'])) {
-            $error = Responses::error(
+            $error                   = Responses::error(
                 'rest_missing_required_params',
                 'rest_missing_required_params',
                 'Faltan campos requeridos.'
             );
-            $error['status'] = 400;
+            $error['status']         = 400;
             $error['missing_fields'] = $validation['missing'];
-            $error['request_id'] = $requestId;
+            $error['request_id']     = $requestId;
 
             return new WP_REST_Response($error, 400);
         }
 
         if (!empty($validation['type'])) {
-            $error = Responses::error(
+            $error               = Responses::error(
                 'rest_invalid_param',
                 'rest_invalid_param',
                 'Tipos inválidos detectados.'
             );
-            $error['status'] = 400;
+            $error['status']     = 400;
             $error['type_errors'] = $validation['type'];
             $error['request_id'] = $requestId;
 
@@ -119,9 +120,9 @@ class ValidateSignController
 
         // TODO(plugin-3-g3d-validate-sign.md §6.1): Validar snapshot, IDs y reglas de catálogo.
 
-        $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $now       = new DateTimeImmutable('now', new DateTimeZone('UTC'));
         $expiresAt = $this->expiry->calculate(null, $now);
-        $signing = $this->signer->sign($sanitized, $this->privateKey, $expiresAt);
+        $signing   = $this->signer->sign($sanitized, $this->privateKey, $expiresAt);
 
         $snapshotId = isset($sanitized['snapshot_id']) ? (string) $sanitized['snapshot_id'] : '';
 
@@ -130,12 +131,12 @@ class ValidateSignController
 
         /** @var ValidateResponse $response */
         $response = Responses::ok([
-            'sku_hash' => $signing['sku_hash'],
+            'sku_hash'      => $signing['sku_hash'],
             'sku_signature' => $signing['signature'],
-            'expires_at' => $this->expiry->format($expiresAt),
-            'snapshot_id' => $snapshotId,
-            'summary' => $summary,
-            'request_id' => $requestId,
+            'expires_at'    => $this->expiry->format($expiresAt),
+            'snapshot_id'   => $snapshotId,
+            'summary'       => $summary,
+            'request_id'    => $requestId,
         ]);
 
         if (array_key_exists('price', $payload)) {

--- a/plugins/g3d-validate-sign/src/Api/ValidateSignController.php
+++ b/plugins/g3d-validate-sign/src/Api/ValidateSignController.php
@@ -9,7 +9,6 @@ use DateTimeZone;
 use G3D\ValidateSign\Crypto\Signer;
 use G3D\ValidateSign\Domain\Expiry;
 use G3D\ValidateSign\Validation\RequestValidator;
-use G3D\VendorBase\Auth\RestPerms;
 use G3D\VendorBase\Rest\Responses;
 use G3D\VendorBase\Rest\Security;
 use WP_Error;
@@ -17,17 +16,31 @@ use WP_REST_Request;
 use WP_REST_Response;
 
 /**
- * REST controller to sign SKU payloads.
+ * @phpstan-type ValidateRequest array{
+ *   schema_version?: string,
+ *   snapshot_id?: string,
+ *   producto_id?: string,
+ *   locale?: string,
+ *   state?: array<string, mixed>,
+ *   flags?: array<string, mixed>
+ * }
+ * @phpstan-type ValidateResponse array{
+ *   ok: true,
+ *   sku_hash: string,
+ *   sku_signature: string,
+ *   expires_at: string,
+ *   snapshot_id?: string,
+ *   summary?: string,
+ *   price?: float|int|string,
+ *   stock?: mixed,
+ *   photo_url?: mixed,
+ *   request_id: string
+ * }
  *
- * Requires the CAP_USE_API capability to access the REST endpoint.
+ * REST controller to sign SKU payloads.
  */
 class ValidateSignController
 {
-    /**
-     * Capability required to consume the Validate & Sign REST API.
-     */
-    public const CAP_USE_API = 'g3d_validate_use_api';
-
     private RequestValidator $validator;
     private Signer $signer;
     private Expiry $expiry;
@@ -53,9 +66,8 @@ class ValidateSignController
             [
                 'methods' => 'POST',
                 'callback' => [$this, 'handle'],
-                'permission_callback' => static function (WP_REST_Request $request): bool {
-                    return RestPerms::canUse(self::CAP_USE_API, $request);
-                },
+                // público según docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada (slots Abiertos) — V2 (urls).md §2.1.
+                'permission_callback' => static fn (): bool => true,
             ]
         );
     }
@@ -102,18 +114,21 @@ class ValidateSignController
             return new WP_REST_Response($error, 400);
         }
 
-        // TODO: Validar snapshot, IDs y reglas de catálogo según docs/plugin-3-g3d-validate-sign.md §6.1.
+        /** @var ValidateRequest $sanitized */
+        $sanitized = $this->sanitizePayload($payload);
+
+        // TODO(plugin-3-g3d-validate-sign.md §6.1): Validar snapshot, IDs y reglas de catálogo.
 
         $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
         $expiresAt = $this->expiry->calculate(null, $now);
-        $signing = $this->signer->sign($payload, $this->privateKey, $expiresAt);
+        $signing = $this->signer->sign($sanitized, $this->privateKey, $expiresAt);
 
-        $snapshotId = isset($payload['snapshot_id']) ? (string) $payload['snapshot_id'] : '';
+        $snapshotId = isset($sanitized['snapshot_id']) ? (string) $sanitized['snapshot_id'] : '';
 
         $summary = $payload['summary'] ?? '{{pieza}} · {{material}} — {{color}} · {{textura}} · {{acabado}}';
-// TODO: Calcular summary real (docs/Capa 1 Identificadores Y Naming —
-// Actualizada (slots Abiertos).md, plantilla resumen).
+        // TODO(Capa 1 Identificadores Y Naming — Actualizada (slots Abiertos).md §resumen): calcular summary real.
 
+        /** @var ValidateResponse $response */
         $response = Responses::ok([
             'sku_hash' => $signing['sku_hash'],
             'sku_signature' => $signing['signature'],
@@ -141,5 +156,41 @@ class ValidateSignController
     private function generateRequestId(): string
     {
         return bin2hex(random_bytes(16));
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return ValidateRequest
+     */
+    private function sanitizePayload(array $payload): array
+    {
+        $sanitized = [];
+
+        if (isset($payload['schema_version']) && is_string($payload['schema_version'])) {
+            $sanitized['schema_version'] = $payload['schema_version'];
+        }
+
+        if (isset($payload['snapshot_id']) && is_string($payload['snapshot_id'])) {
+            $sanitized['snapshot_id'] = $payload['snapshot_id'];
+        }
+
+        if (isset($payload['producto_id']) && is_string($payload['producto_id'])) {
+            $sanitized['producto_id'] = $payload['producto_id'];
+        }
+
+        if (isset($payload['locale']) && is_string($payload['locale'])) {
+            $sanitized['locale'] = $payload['locale'];
+        }
+
+        if (isset($payload['state']) && is_array($payload['state'])) {
+            $sanitized['state'] = $payload['state'];
+        }
+
+        if (isset($payload['flags']) && is_array($payload['flags'])) {
+            $sanitized['flags'] = $payload['flags'];
+        }
+
+        return $sanitized;
     }
 }

--- a/plugins/g3d-validate-sign/tests/Api/PermissionsTest.php
+++ b/plugins/g3d-validate-sign/tests/Api/PermissionsTest.php
@@ -26,18 +26,18 @@ final class PermissionsTest extends TestCase
         $this->registerRoutes();
     }
 
-    public function testValidateSignRouteRequiresNonceAndCapability(): void
+    public function testValidateSignRouteIsPublicAccordingDocs(): void
     {
         $callback = $this->getPermissionCallback('/validate-sign');
 
-        $this->assertPermissionMatrix($callback, '/validate-sign');
+        $this->assertRouteIsPublic($callback, '/validate-sign');
     }
 
-    public function testVerifyRouteRequiresNonceAndCapability(): void
+    public function testVerifyRouteIsPublicAccordingDocs(): void
     {
         $callback = $this->getPermissionCallback('/verify');
 
-        $this->assertPermissionMatrix($callback, '/verify');
+        $this->assertRouteIsPublic($callback, '/verify');
     }
 
     /**
@@ -57,7 +57,7 @@ final class PermissionsTest extends TestCase
         self::fail('Route not registered: ' . $route);
     }
 
-    private function assertPermissionMatrix(callable $callback, string $route): void
+    private function assertRouteIsPublic(callable $callback, string $route): void
     {
         Perms::allowAll();
         Nonce::allow();
@@ -67,17 +67,17 @@ final class PermissionsTest extends TestCase
         Perms::denyAll();
         Nonce::allow();
         $request = $this->createRequest($route, true);
-        self::assertFalse($callback($request));
+        self::assertTrue($callback($request));
 
         Perms::allowAll();
-        Nonce::allow();
+        Nonce::deny();
         $request = $this->createRequest($route, false);
-        self::assertFalse($callback($request));
+        self::assertTrue($callback($request));
 
         Perms::denyAll();
-        Nonce::allow();
+        Nonce::deny();
         $request = $this->createRequest($route, false);
-        self::assertFalse($callback($request));
+        self::assertTrue($callback($request));
     }
 
     private function createRequest(string $route, bool $withNonce): WP_REST_Request

--- a/plugins/g3d-validate-sign/tests/bootstrap.php
+++ b/plugins/g3d-validate-sign/tests/bootstrap.php
@@ -2,6 +2,14 @@
 // phpcs:ignoreFile
 declare(strict_types=1);
 
+if (!extension_loaded('sodium')) {
+    $sodiumCompatAutoload = __DIR__ . '/../vendor/paragonie/sodium_compat/autoload.php';
+
+    if (is_file($sodiumCompatAutoload)) {
+        require_once $sodiumCompatAutoload;
+    }
+}
+
 require_once __DIR__ . '/../../g3d-vendor-base-helper/tests/bootstrap.php';
 
 spl_autoload_register(static function (string $class): void {


### PR DESCRIPTION
## Summary
- exponer /g3d/v1/validate-sign y /g3d/v1/verify como endpoints públicos y tipados según los esquemas mínimos documentados, normalizando firmas, expiraciones y shape de errores
- sanear y firmar los payloads de validación/verificación con request_id, TTL ISO-8601 y prefijo sig.vN mientras dejamos TODOs donde la documentación aún no concreta reglas adicionales
- ampliar la batería de tests REST para cubrir campos requeridos/tipos, prefijos inválidos, caducidad y compatibilidad con sodium_compat al faltar la extensión nativa

## Testing
- composer phpcs
- composer phpstan
- composer test
- ./vendor/bin/phpunit --configuration plugins/g3d-validate-sign/phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68db76e82b3083239d465bd18707d32a