### PR TITLE
feat(p4f): gating de CTAs del Wizard por reglas (P2) + mensajes accesibles (aria-live) + tests

### DIFF
--- a/plugins/gafas3d-wizard-modal/assets/css/wizard-modal.css
+++ b/plugins/gafas3d-wizard-modal/assets/css/wizard-modal.css
@@ -43,7 +43,7 @@ body.g3d-wizard-open {
 }
 
 .g3d-wizard-modal__msg {
-  margin-top: 0.5rem;
+  margin-top: .5rem;
   font-size: 0.875rem;
   min-height: 1.5em;
 }
@@ -62,7 +62,8 @@ body.g3d-wizard-open {
   margin-left: 0.75rem;
 }
 
-.g3d-wizard-modal__footer button[disabled] {
-  opacity: 0.6;
+.g3d-wizard-modal__cta[disabled],
+.g3d-wizard-modal__verify[disabled] {
+  opacity: .5;
   cursor: not-allowed;
 }

--- a/plugins/gafas3d-wizard-modal/tests/UI/ModalRenderTest.php
+++ b/plugins/gafas3d-wizard-modal/tests/UI/ModalRenderTest.php
@@ -21,6 +21,8 @@ final class ModalRenderTest extends TestCase
         self::assertStringContainsString('data-producto-id=""', $output);
         self::assertStringContainsString('data-locale="', $output);
         self::assertStringContainsString('class="g3d-wizard-modal__rules"', $output);
+        self::assertStringContainsString('data-g3d-wizard-modal-cta', $output);
+        self::assertStringContainsString('data-g3d-wizard-modal-verify', $output);
     }
 
     public function testRenderContainsSinglePoliteMessageRegion(): void


### PR DESCRIPTION
## Summary
- implement gateCtasByRules to evaluate catalog rules payloads, toggle CTA availability, and surface missing-field warnings alongside existing aria-live updates
- adjust modal messaging and button states (including aria-disabled) plus CSS feedback to keep status announcements accessible during rule loads
- extend modal render coverage to assert CTA data attributes and aria-live container availability

## Testing
- composer phpcs
- composer phpstan
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dc2cd6b41c8323abeb9f3bcbc94630