### PR TITLE
feat(p3): TTL/caducidad exacta + prefijos de firma permitidos + Clock inyectable (tests)

### DIFF
--- a/plugins/g3d-validate-sign/plugin.php
+++ b/plugins/g3d-validate-sign/plugin.php
@@ -17,8 +17,8 @@ use G3D\ValidateSign\Api\ValidateSignController;
 use G3D\ValidateSign\Api\VerifyController;
 use G3D\ValidateSign\Crypto\Signer;
 use G3D\ValidateSign\Crypto\Verifier;
-use G3D\ValidateSign\Domain\Expiry;
 use G3D\ValidateSign\Validation\RequestValidator;
+use G3D\VendorBase\Time\SystemClock;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -34,14 +34,14 @@ add_action('rest_api_init', static function (): void {
     $validateValidator = new RequestValidator($schemaDir . '/validate-sign.request.schema.json');
     $verifyValidator = new RequestValidator($schemaDir . '/verify.request.schema.json');
 
-    $expiry = new Expiry();
-    $signer = new Signer();
+    $clock = new SystemClock();
+    $signer = new Signer(null, $clock);
     $privateKey = defined('G3D_VALIDATE_SIGN_PRIVATE_KEY') ? (string) G3D_VALIDATE_SIGN_PRIVATE_KEY : '';
-    $validateController = new ValidateSignController($validateValidator, $signer, $expiry, $privateKey);
+    $validateController = new ValidateSignController($validateValidator, $signer, $privateKey);
 
-    $verifier = new Verifier();
+    $verifier = new Verifier(Signer::ALLOWED_SIGNATURE_PREFIXES, $clock);
     $publicKey = defined('G3D_VALIDATE_SIGN_PUBLIC_KEY') ? (string) G3D_VALIDATE_SIGN_PUBLIC_KEY : '';
-    $verifyController = new VerifyController($verifyValidator, $verifier, $expiry, $publicKey);
+    $verifyController = new VerifyController($verifyValidator, $verifier, $publicKey);
 
     $validateController->registerRoutes();
     $verifyController->registerRoutes();

--- a/plugins/g3d-validate-sign/src/Api/ValidateSignController.php
+++ b/plugins/g3d-validate-sign/src/Api/ValidateSignController.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace G3D\ValidateSign\Api;
 
-use DateTimeImmutable;
-use DateTimeZone;
 use G3D\ValidateSign\Crypto\Signer;
-use G3D\ValidateSign\Domain\Expiry;
 use G3D\ValidateSign\Validation\RequestValidator;
 use G3D\VendorBase\Rest\Security;
 use WP_Error;
@@ -42,18 +39,15 @@ class ValidateSignController
 {
     private RequestValidator $validator;
     private Signer $signer;
-    private Expiry $expiry;
     private string $privateKey;
 
     public function __construct(
         RequestValidator $validator,
         Signer $signer,
-        Expiry $expiry,
         string $privateKey
     ) {
         $this->validator  = $validator;
         $this->signer     = $signer;
-        $this->expiry     = $expiry;
         $this->privateKey = $privateKey;
     }
 
@@ -119,9 +113,7 @@ class ValidateSignController
 
         // TODO(plugin-3-g3d-validate-sign.md §6.1): Validar snapshot, IDs y reglas de catálogo.
 
-        $now       = new DateTimeImmutable('now', new DateTimeZone('UTC'));
-        $expiresAt = $this->expiry->calculate(null, $now);
-        $signing   = $this->signer->sign($sanitized, $this->privateKey, $expiresAt);
+        $signing   = $this->signer->sign($sanitized, $this->privateKey);
 
         $snapshotId = isset($sanitized['snapshot_id']) ? (string) $sanitized['snapshot_id'] : '';
 

--- a/plugins/g3d-validate-sign/src/Api/VerifyController.php
+++ b/plugins/g3d-validate-sign/src/Api/VerifyController.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace G3D\ValidateSign\Api;
 
-use DateTimeImmutable;
-use DateTimeZone;
 use G3D\ValidateSign\Crypto\Verifier;
-use G3D\ValidateSign\Domain\Expiry;
 use G3D\ValidateSign\Validation\RequestValidator;
 use G3D\VendorBase\Rest\Responses;
 use G3D\VendorBase\Rest\Security;
@@ -32,18 +29,15 @@ class VerifyController
 {
     private RequestValidator $validator;
     private Verifier $verifier;
-    private Expiry $expiry;
     private string $publicKey;
 
     public function __construct(
         RequestValidator $validator,
         Verifier $verifier,
-        Expiry $expiry,
         string $publicKey
     ) {
         $this->validator = $validator;
         $this->verifier  = $verifier;
-        $this->expiry    = $expiry;
         $this->publicKey = $publicKey;
     }
 
@@ -104,7 +98,6 @@ class VerifyController
             );
         }
 
-        $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
         /** @var VerifyPayload $sanitized */
         $sanitized = $this->sanitizePayload($payload);
 
@@ -122,20 +115,6 @@ class VerifyController
             $errorResponse['request_id'] = $requestId;
 
             return new WP_REST_Response($errorResponse, $status);
-        }
-
-        $expiresAt = $verification['expires_at'];
-
-        if ($this->expiry->isExpired($expiresAt, $now)) {
-            $errorResponse = Responses::error(
-                'E_SIGN_EXPIRED',
-                'sign_expired',
-                'Firma caducada según docs/Capa 3 — Validación, Firma Y Caducidad — Actualizada '
-                . '(slots Abiertos) — V2 (urls).md.'
-            );
-            $errorResponse['request_id'] = $requestId;
-
-            return new WP_REST_Response($errorResponse, 400);
         }
 
         /** @var VerifyResponse $response */

--- a/plugins/g3d-validate-sign/src/Crypto/Verifier.php
+++ b/plugins/g3d-validate-sign/src/Crypto/Verifier.php
@@ -22,8 +22,7 @@ class Verifier
     public function __construct(
         array $allowedPrefixes = Signer::ALLOWED_SIGNATURE_PREFIXES,
         ?Clock $clock = null
-    )
-    {
+    ) {
         if (!function_exists('sodium_crypto_sign_verify_detached')) {
             throw new RuntimeException(
                 'ext-sodium requerida (ver docs/plugin-3-g3d-validate-sign.md §4.1 y '
@@ -198,10 +197,10 @@ class Verifier
             );
         }
 
-        $signatureSkuHash     = $decoded['sku_hash'];
-        $signatureSnapshotId  = $decoded['snapshot_id'];
-        $requestedSkuHash     = isset($payload['sku_hash']) ? (string) $payload['sku_hash'] : '';
-        $requestedSnapshotId  = isset($payload['snapshot_id']) ? (string) $payload['snapshot_id'] : '';
+        $signatureSkuHash    = $decoded['sku_hash'];
+        $signatureSnapshotId = $decoded['snapshot_id'];
+        $requestedSkuHash    = isset($payload['sku_hash']) ? (string) $payload['sku_hash'] : '';
+        $requestedSnapshotId = isset($payload['snapshot_id']) ? (string) $payload['snapshot_id'] : '';
 
         if ($signatureSkuHash !== $requestedSkuHash) {
             return $this->error(

--- a/plugins/g3d-validate-sign/tests/Api/PermissionsTest.php
+++ b/plugins/g3d-validate-sign/tests/Api/PermissionsTest.php
@@ -6,7 +6,6 @@ namespace G3D\ValidateSign\Tests\Api;
 
 use G3D\ValidateSign\Api\ValidateSignController;
 use G3D\ValidateSign\Api\VerifyController;
-use G3D\ValidateSign\Domain\Expiry;
 use G3D\ValidateSign\Validation\RequestValidator;
 use PHPUnit\Framework\TestCase;
 use Test_Env\Nonce;
@@ -94,20 +93,18 @@ final class PermissionsTest extends TestCase
     private function registerRoutes(): void
     {
         $validator = $this->createStub(RequestValidator::class);
-        $expiry = new Expiry();
-
         $signer = $this->getMockBuilder(\G3D\ValidateSign\Crypto\Signer::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $validateController = new ValidateSignController($validator, $signer, $expiry, 'private-key');
+        $validateController = new ValidateSignController($validator, $signer, 'private-key');
         $validateController->registerRoutes();
 
         $verifier = $this->getMockBuilder(\G3D\ValidateSign\Crypto\Verifier::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $verifyController = new VerifyController($validator, $verifier, $expiry, 'public-key');
+        $verifyController = new VerifyController($validator, $verifier, 'public-key');
         $verifyController->registerRoutes();
     }
 }

--- a/plugins/g3d-validate-sign/tests/Api/ValidateSignRouteTest.php
+++ b/plugins/g3d-validate-sign/tests/Api/ValidateSignRouteTest.php
@@ -148,5 +148,4 @@ final class ValidateSignRouteTest extends TestCase
         self::assertMatchesRegularExpression('/^[0-9a-f]{32}$/', (string) $data['request_id']);
         self::assertArrayHasKey('type_errors', $data);
     }
-
 }

--- a/plugins/g3d-validate-sign/tests/Api/ValidateSignRouteTest.php
+++ b/plugins/g3d-validate-sign/tests/Api/ValidateSignRouteTest.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace G3D\ValidateSign\Tests\Api;
 
-use DateTimeImmutable;
-use DateTimeInterface;
 use G3D\ValidateSign\Api\ValidateSignController;
 use G3D\ValidateSign\Crypto\Signer;
-use G3D\ValidateSign\Domain\Expiry;
 use G3D\ValidateSign\Validation\RequestValidator;
+use G3D\VendorBase\Time\FixedClock;
 use PHPUnit\Framework\TestCase;
 use WP_Error;
 use WP_REST_Request;
@@ -33,13 +31,13 @@ final class ValidateSignRouteTest extends TestCase
     {
         $schemaPath = __DIR__ . '/../../schemas/validate-sign.request.schema.json';
         $validator  = new RequestValidator($schemaPath);
-        $fixedNow   = new DateTimeImmutable('2025-09-29T00:00:00+00:00');
-        $expiry     = $this->createExpiry($fixedNow, 30, false);
-        $signer     = new Signer('sig.v1');
+        $fixedNow   = new \DateTimeImmutable('2025-09-29T00:00:00+00:00');
+        $clock      = new FixedClock($fixedNow);
+        $signer     = new Signer('sig.v1', $clock);
         $keyPair    = sodium_crypto_sign_keypair();
         $privateKey = sodium_crypto_sign_secretkey($keyPair);
 
-        $controller = new ValidateSignController($validator, $signer, $expiry, $privateKey);
+        $controller = new ValidateSignController($validator, $signer, $privateKey);
 
         $payload = [
             'schema_version' => '1.0.0',
@@ -85,12 +83,12 @@ final class ValidateSignRouteTest extends TestCase
     {
         $schemaPath = __DIR__ . '/../../schemas/validate-sign.request.schema.json';
         $validator  = new RequestValidator($schemaPath);
-        $expiry     = $this->createExpiry(new DateTimeImmutable('2025-09-29T00:00:00+00:00'), 30, false);
-        $signer     = new Signer('sig.v1');
+        $clock      = new FixedClock(new \DateTimeImmutable('2025-09-29T00:00:00+00:00'));
+        $signer     = new Signer('sig.v1', $clock);
         $keyPair    = sodium_crypto_sign_keypair();
         $privateKey = sodium_crypto_sign_secretkey($keyPair);
 
-        $controller = new ValidateSignController($validator, $signer, $expiry, $privateKey);
+        $controller = new ValidateSignController($validator, $signer, $privateKey);
 
         $payload = [
             'schema_version' => '1.0.0',
@@ -119,12 +117,12 @@ final class ValidateSignRouteTest extends TestCase
     {
         $schemaPath = __DIR__ . '/../../schemas/validate-sign.request.schema.json';
         $validator  = new RequestValidator($schemaPath);
-        $expiry     = $this->createExpiry(new DateTimeImmutable('2025-09-29T00:00:00+00:00'), 30, false);
-        $signer     = new Signer('sig.v1');
+        $clock      = new FixedClock(new \DateTimeImmutable('2025-09-29T00:00:00+00:00'));
+        $signer     = new Signer('sig.v1', $clock);
         $keyPair    = sodium_crypto_sign_keypair();
         $privateKey = sodium_crypto_sign_secretkey($keyPair);
 
-        $controller = new ValidateSignController($validator, $signer, $expiry, $privateKey);
+        $controller = new ValidateSignController($validator, $signer, $privateKey);
 
         $payload = [
             'schema_version' => '1.0.0',
@@ -151,38 +149,4 @@ final class ValidateSignRouteTest extends TestCase
         self::assertArrayHasKey('type_errors', $data);
     }
 
-    private function createExpiry(DateTimeImmutable $now, int $ttlDays, bool $forceExpired): Expiry
-    {
-        return new class ($now, $ttlDays, $forceExpired) extends Expiry
-        {
-            private DateTimeImmutable $fixedNow;
-            private int $fixedTtl;
-            private bool $expired;
-
-            public function __construct(DateTimeImmutable $fixedNow, int $fixedTtl, bool $expired)
-            {
-                parent::__construct($fixedTtl);
-                $this->fixedNow = $fixedNow;
-                $this->fixedTtl = $fixedTtl;
-                $this->expired  = $expired;
-            }
-
-            public function calculate(?int $ttlDays = null, ?DateTimeImmutable $now = null): DateTimeImmutable
-            {
-                $days = $ttlDays ?? $this->fixedTtl;
-
-                return $this->fixedNow->modify(sprintf('+%d days', $days));
-            }
-
-            public function format(DateTimeImmutable $expiresAt): string
-            {
-                return $expiresAt->format(DateTimeInterface::ATOM);
-            }
-
-            public function isExpired(DateTimeImmutable $expiresAt, ?DateTimeImmutable $now = null): bool
-            {
-                return $this->expired;
-            }
-        };
-    }
 }

--- a/plugins/g3d-validate-sign/tests/Api/VerifyRouteTest.php
+++ b/plugins/g3d-validate-sign/tests/Api/VerifyRouteTest.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace G3D\ValidateSign\Tests\Api;
 
-use DateTimeImmutable;
-use DateTimeInterface;
 use G3D\ValidateSign\Api\VerifyController;
 use G3D\ValidateSign\Crypto\Signer;
 use G3D\ValidateSign\Crypto\Verifier;
-use G3D\ValidateSign\Domain\Expiry;
 use G3D\ValidateSign\Validation\RequestValidator;
+use G3D\VendorBase\Time\FixedClock;
 use PHPUnit\Framework\TestCase;
 use WP_Error;
 use WP_REST_Request;
@@ -34,9 +32,9 @@ final class VerifyRouteTest extends TestCase
     {
         $schemaPath = __DIR__ . '/../../schemas/verify.request.schema.json';
         $validator  = new RequestValidator($schemaPath);
-        $verifier   = new Verifier(['sig.v1']);
-        $expiry     = $this->createExpiry(new DateTimeImmutable('2025-09-29T00:00:00+00:00'), 30, false);
-        $signer     = new Signer('sig.v1');
+        $clock      = new FixedClock(new \DateTimeImmutable('2025-09-29T00:00:00+00:00'));
+        $verifier   = new Verifier(['sig.v1'], $clock);
+        $signer     = new Signer('sig.v1', $clock);
         $keyPair    = sodium_crypto_sign_keypair();
         $privateKey = sodium_crypto_sign_secretkey($keyPair);
         $publicKey  = sodium_crypto_sign_publickey($keyPair);
@@ -48,10 +46,9 @@ final class VerifyRouteTest extends TestCase
             'state'          => [],
         ];
 
-        $expiresAt = new DateTimeImmutable('2025-10-29T00:00:00+00:00');
-        $signed    = $signer->sign($signingPayload, $privateKey, $expiresAt);
+        $signed    = $signer->sign($signingPayload, $privateKey);
 
-        $controller = new VerifyController($validator, $verifier, $expiry, $publicKey);
+        $controller = new VerifyController($validator, $verifier, $publicKey);
 
         $requestPayload = [
             'sku_hash'      => $signed['sku_hash'],
@@ -76,9 +73,9 @@ final class VerifyRouteTest extends TestCase
     {
         $schemaPath = __DIR__ . '/../../schemas/verify.request.schema.json';
         $validator  = new RequestValidator($schemaPath);
-        $verifier   = new Verifier(['sig.v1']);
-        $expiry     = $this->createExpiry(new DateTimeImmutable('2025-09-29T00:00:00+00:00'), 30, true);
-        $signer     = new Signer('sig.v1');
+        $clock      = new FixedClock(new \DateTimeImmutable('2025-09-29T00:00:00+00:00'));
+        $verifier   = new Verifier(['sig.v1'], $clock);
+        $signer     = new Signer('sig.v1', $clock);
         $keyPair    = sodium_crypto_sign_keypair();
         $privateKey = sodium_crypto_sign_secretkey($keyPair);
         $publicKey  = sodium_crypto_sign_publickey($keyPair);
@@ -88,10 +85,11 @@ final class VerifyRouteTest extends TestCase
             'state'       => [],
         ];
 
-        $expiresAt = new DateTimeImmutable('2025-09-30T00:00:00+00:00');
-        $signed    = $signer->sign($signingPayload, $privateKey, $expiresAt);
+        $signed    = $signer->sign($signingPayload, $privateKey);
 
-        $controller = new VerifyController($validator, $verifier, $expiry, $publicKey);
+        $clock->advance(new \DateInterval('P31D'));
+
+        $controller = new VerifyController($validator, $verifier, $publicKey);
         $request = new WP_REST_Request('POST', '/g3d/v1/verify');
         $request->set_header('Content-Type', 'application/json');
         $request->set_body((string) json_encode([
@@ -115,9 +113,9 @@ final class VerifyRouteTest extends TestCase
     {
         $schemaPath = __DIR__ . '/../../schemas/verify.request.schema.json';
         $validator  = new RequestValidator($schemaPath);
-        $verifier   = new Verifier(['sig.v1']);
-        $expiry     = $this->createExpiry(new DateTimeImmutable('2025-09-29T00:00:00+00:00'), 30, false);
-        $signer     = new Signer('sig.v1');
+        $clock      = new FixedClock(new \DateTimeImmutable('2025-09-29T00:00:00+00:00'));
+        $verifier   = new Verifier(['sig.v1'], $clock);
+        $signer     = new Signer('sig.v1', $clock);
         $keyPair    = sodium_crypto_sign_keypair();
         $privateKey = sodium_crypto_sign_secretkey($keyPair);
         $publicKey  = sodium_crypto_sign_publickey($keyPair);
@@ -127,10 +125,9 @@ final class VerifyRouteTest extends TestCase
             'state'       => [],
         ];
 
-        $expiresAt = new DateTimeImmutable('2025-10-29T00:00:00+00:00');
-        $signed    = $signer->sign($signingPayload, $privateKey, $expiresAt);
+        $signed    = $signer->sign($signingPayload, $privateKey);
 
-        $controller = new VerifyController($validator, $verifier, $expiry, $publicKey);
+        $controller = new VerifyController($validator, $verifier, $publicKey);
         $request = new WP_REST_Request('POST', '/g3d/v1/verify');
         $request->set_header('Content-Type', 'application/json');
         $request->set_body((string) json_encode([
@@ -154,9 +151,9 @@ final class VerifyRouteTest extends TestCase
     {
         $schemaPath = __DIR__ . '/../../schemas/verify.request.schema.json';
         $validator  = new RequestValidator($schemaPath);
-        $verifier   = new Verifier(['sig.v1']);
-        $expiry     = $this->createExpiry(new DateTimeImmutable('2025-09-29T00:00:00+00:00'), 30, false);
-        $signer     = new Signer('sig.v1');
+        $clock      = new FixedClock(new \DateTimeImmutable('2025-09-29T00:00:00+00:00'));
+        $verifier   = new Verifier(['sig.v1'], $clock);
+        $signer     = new Signer('sig.v1', $clock);
         $keyPair    = sodium_crypto_sign_keypair();
         $privateKey = sodium_crypto_sign_secretkey($keyPair);
         $publicKey  = sodium_crypto_sign_publickey($keyPair);
@@ -166,11 +163,10 @@ final class VerifyRouteTest extends TestCase
             'state'       => [],
         ];
 
-        $expiresAt = new DateTimeImmutable('2025-10-29T00:00:00+00:00');
-        $signed    = $signer->sign($signingPayload, $privateKey, $expiresAt);
+        $signed    = $signer->sign($signingPayload, $privateKey);
         $manipulatedSignature = (string) preg_replace('/^sig\\.v1/', 'sig.v2', $signed['signature']);
 
-        $controller = new VerifyController($validator, $verifier, $expiry, $publicKey);
+        $controller = new VerifyController($validator, $verifier, $publicKey);
         $request = new WP_REST_Request('POST', '/g3d/v1/verify');
         $request->set_header('Content-Type', 'application/json');
         $request->set_body((string) json_encode([
@@ -194,9 +190,9 @@ final class VerifyRouteTest extends TestCase
     {
         $schemaPath = __DIR__ . '/../../schemas/verify.request.schema.json';
         $validator  = new RequestValidator($schemaPath);
-        $verifier   = new Verifier(['sig.v1']);
-        $expiry     = $this->createExpiry(new DateTimeImmutable('2025-09-29T00:00:00+00:00'), 30, false);
-        $signer     = new Signer('sig.v1');
+        $clock      = new FixedClock(new \DateTimeImmutable('2025-09-29T00:00:00+00:00'));
+        $verifier   = new Verifier(['sig.v1'], $clock);
+        $signer     = new Signer('sig.v1', $clock);
         $keyPair    = sodium_crypto_sign_keypair();
         $privateKey = sodium_crypto_sign_secretkey($keyPair);
         $publicKey  = sodium_crypto_sign_publickey($keyPair);
@@ -206,10 +202,9 @@ final class VerifyRouteTest extends TestCase
             'state'       => [],
         ];
 
-        $expiresAt = new DateTimeImmutable('2025-10-29T00:00:00+00:00');
-        $signed    = $signer->sign($signingPayload, $privateKey, $expiresAt);
+        $signed    = $signer->sign($signingPayload, $privateKey);
 
-        $controller = new VerifyController($validator, $verifier, $expiry, $publicKey);
+        $controller = new VerifyController($validator, $verifier, $publicKey);
         $request = new WP_REST_Request('POST', '/g3d/v1/verify');
         $request->set_header('Content-Type', 'application/json');
         $request->set_body((string) json_encode([
@@ -234,8 +229,7 @@ final class VerifyRouteTest extends TestCase
         $schemaPath = __DIR__ . '/../../schemas/verify.request.schema.json';
         $validator  = new RequestValidator($schemaPath);
         $verifier   = new Verifier(['sig.v1']);
-        $expiry     = $this->createExpiry(new DateTimeImmutable('2025-09-29T00:00:00+00:00'), 30, false);
-        $controller = new VerifyController($validator, $verifier, $expiry, 'public-key');
+        $controller = new VerifyController($validator, $verifier, 'public-key');
 
         $request = new WP_REST_Request('POST', '/g3d/v1/verify');
         $request->set_header('Content-Type', 'application/json');
@@ -261,8 +255,7 @@ final class VerifyRouteTest extends TestCase
         $schemaPath = __DIR__ . '/../../schemas/verify.request.schema.json';
         $validator  = new RequestValidator($schemaPath);
         $verifier   = new Verifier(['sig.v1']);
-        $expiry     = $this->createExpiry(new DateTimeImmutable('2025-09-29T00:00:00+00:00'), 30, false);
-        $controller = new VerifyController($validator, $verifier, $expiry, 'public-key');
+        $controller = new VerifyController($validator, $verifier, 'public-key');
 
         $request = new WP_REST_Request('POST', '/g3d/v1/verify');
         $request->set_header('Content-Type', 'application/json');
@@ -284,38 +277,4 @@ final class VerifyRouteTest extends TestCase
         self::assertMatchesRegularExpression('/^[0-9a-f]{32}$/', (string) $data['request_id']);
     }
 
-    private function createExpiry(DateTimeImmutable $now, int $ttlDays, bool $forceExpired): Expiry
-    {
-        return new class ($now, $ttlDays, $forceExpired) extends Expiry
-        {
-            private DateTimeImmutable $fixedNow;
-            private int $fixedTtl;
-            private bool $expired;
-
-            public function __construct(DateTimeImmutable $fixedNow, int $fixedTtl, bool $expired)
-            {
-                parent::__construct($fixedTtl);
-                $this->fixedNow = $fixedNow;
-                $this->fixedTtl = $fixedTtl;
-                $this->expired  = $expired;
-            }
-
-            public function calculate(?int $ttlDays = null, ?DateTimeImmutable $now = null): DateTimeImmutable
-            {
-                $days = $ttlDays ?? $this->fixedTtl;
-
-                return $this->fixedNow->modify(sprintf('+%d days', $days));
-            }
-
-            public function format(DateTimeImmutable $expiresAt): string
-            {
-                return $expiresAt->format(DateTimeInterface::ATOM);
-            }
-
-            public function isExpired(DateTimeImmutable $expiresAt, ?DateTimeImmutable $now = null): bool
-            {
-                return $this->expired;
-            }
-        };
-    }
 }

--- a/plugins/g3d-validate-sign/tests/Api/VerifyRouteTest.php
+++ b/plugins/g3d-validate-sign/tests/Api/VerifyRouteTest.php
@@ -46,7 +46,7 @@ final class VerifyRouteTest extends TestCase
             'state'          => [],
         ];
 
-        $signed    = $signer->sign($signingPayload, $privateKey);
+        $signed = $signer->sign($signingPayload, $privateKey);
 
         $controller = new VerifyController($validator, $verifier, $publicKey);
 
@@ -85,7 +85,7 @@ final class VerifyRouteTest extends TestCase
             'state'       => [],
         ];
 
-        $signed    = $signer->sign($signingPayload, $privateKey);
+        $signed = $signer->sign($signingPayload, $privateKey);
 
         $clock->advance(new \DateInterval('P31D'));
 
@@ -125,7 +125,7 @@ final class VerifyRouteTest extends TestCase
             'state'       => [],
         ];
 
-        $signed    = $signer->sign($signingPayload, $privateKey);
+        $signed = $signer->sign($signingPayload, $privateKey);
 
         $controller = new VerifyController($validator, $verifier, $publicKey);
         $request = new WP_REST_Request('POST', '/g3d/v1/verify');
@@ -163,7 +163,7 @@ final class VerifyRouteTest extends TestCase
             'state'       => [],
         ];
 
-        $signed    = $signer->sign($signingPayload, $privateKey);
+        $signed = $signer->sign($signingPayload, $privateKey);
         $manipulatedSignature = (string) preg_replace('/^sig\\.v1/', 'sig.v2', $signed['signature']);
 
         $controller = new VerifyController($validator, $verifier, $publicKey);
@@ -202,7 +202,7 @@ final class VerifyRouteTest extends TestCase
             'state'       => [],
         ];
 
-        $signed    = $signer->sign($signingPayload, $privateKey);
+        $signed = $signer->sign($signingPayload, $privateKey);
 
         $controller = new VerifyController($validator, $verifier, $publicKey);
         $request = new WP_REST_Request('POST', '/g3d/v1/verify');
@@ -276,5 +276,4 @@ final class VerifyRouteTest extends TestCase
         self::assertArrayHasKey('request_id', $data);
         self::assertMatchesRegularExpression('/^[0-9a-f]{32}$/', (string) $data['request_id']);
     }
-
 }

--- a/plugins/g3d-vendor-base-helper/src/Time/Clock.php
+++ b/plugins/g3d-vendor-base-helper/src/Time/Clock.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Time;
+
+interface Clock
+{
+    public function now(): \DateTimeImmutable;
+}

--- a/plugins/g3d-vendor-base-helper/src/Time/FixedClock.php
+++ b/plugins/g3d-vendor-base-helper/src/Time/FixedClock.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Time;
+
+final class FixedClock implements Clock
+{
+    public function __construct(private \DateTimeImmutable $fixed)
+    {
+    }
+
+    public function now(): \DateTimeImmutable
+    {
+        return $this->fixed;
+    }
+
+    public function advance(\DateInterval $delta): void
+    {
+        $this->fixed = $this->fixed->add($delta);
+    }
+}

--- a/plugins/g3d-vendor-base-helper/src/Time/SystemClock.php
+++ b/plugins/g3d-vendor-base-helper/src/Time/SystemClock.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace G3D\VendorBase\Time;
+
+final class SystemClock implements Clock
+{
+    public function now(): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+    }
+}


### PR DESCRIPTION
## Summary
- add vendor Clock helpers (system + fixed) to centralize time access
- inject the clock into signer/verifier to compute 30-day TTL, format ISO-8601 expires_at, and reject prefixes/firmas caducadas según docs
- rewire controllers/bootstrap and refresh route/unit tests with FixedClock coverage for valid, expired, and invalid-prefix cases

## Testing
- composer phpcs
- composer phpstan
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dc446f709483238fabb8004ffb5f45