### PR TITLE
feat(p4): wizard ← reglas de catálogo (fetch al abrir, UI mínima) + tests

### DIFF
--- a/plugins/gafas3d-wizard-modal/assets/css/wizard-modal.css
+++ b/plugins/gafas3d-wizard-modal/assets/css/wizard-modal.css
@@ -35,7 +35,7 @@ body.g3d-wizard-open {
 }
 
 .g3d-wizard-modal__rules {
-  margin-top: 0.75rem;
+  margin-top: 0.5rem;
   font-size: 0.875rem;
   line-height: 1.4;
   min-height: 1.5em;

--- a/plugins/gafas3d-wizard-modal/assets/js/wizard-modal.js
+++ b/plugins/gafas3d-wizard-modal/assets/js/wizard-modal.js
@@ -10,6 +10,30 @@
 
   global.G3DWIZARD = global.G3DWIZARD || {};
 
+  function getJSON(url, params, options) {
+    var query = '';
+
+    if (params && Object.keys(params).length) {
+      query =
+        '?' +
+        Object.keys(params)
+          .map(function (key) {
+            return (
+              encodeURIComponent(key) + '=' + encodeURIComponent(params[key])
+            );
+          })
+          .join('&');
+    }
+
+    var init = { method: 'GET' };
+
+    if (options && options.signal) {
+      init.signal = options.signal;
+    }
+
+    return fetch(url + query, init);
+  }
+
   global.G3DWIZARD.getJson =
     global.G3DWIZARD.getJson ||
     (async function (url, params, options) {
@@ -974,25 +998,13 @@
         setBusy(rulesContainer, true);
       }
 
-      if (!productoId) {
-        lastRules = null;
-        setRulesSummaryMessage('Reglas ERROR — missing producto_id');
-        // TODO(docs/plugin-2-g3d-catalog-rules.md §6 APIs / Contratos (lectura))
-        // confirmar parámetros requeridos.
+      var params = {};
 
-        releaseButtons();
-        setBusy(message, false);
-
-        if (rulesContainer) {
-          setBusy(rulesContainer, false);
-        }
-
-        gateCtasByRules(lastRules);
-
-        return;
+      if (productoId) {
+        // TODO(docs/plugin-2-g3d-catalog-rules.md §6 APIs / Contratos (lectura)):
+        // confirmar si el parámetro usa snake_case exacto.
+        params.producto_id = productoId;
       }
-
-      var params = { producto_id: productoId };
 
       if (snapshotId) {
         params.snapshot_id = snapshotId;
@@ -1025,7 +1037,7 @@
       var signal = controller ? controller.signal : undefined;
 
       try {
-        var response = await global.G3DWIZARD.getJson(url, params, {
+        var response = await getJSON(url, params, {
           signal: signal,
         });
 

--- a/plugins/gafas3d-wizard-modal/tests/Assets/AssetsTest.php
+++ b/plugins/gafas3d-wizard-modal/tests/Assets/AssetsTest.php
@@ -57,8 +57,10 @@ final class AssetsTest extends TestCase
             $localized['api']['audit'] ?? null
         );
         self::assertArrayHasKey('rules', $localized['api']);
-        self::assertIsString($localized['api']['rules']);
-        self::assertStringStartsWith('http://example.test/wp-json/', $localized['api']['rules']);
+        self::assertSame(
+            'http://example.test/wp-json/g3d/v1/catalog/rules',
+            $localized['api']['rules'] ?? null
+        );
         self::assertArrayHasKey('nonce', $localized);
         self::assertSame('nonce-123', $localized['nonce'] ?? null);
         self::assertArrayHasKey('locale', $localized);


### PR DESCRIPTION
## Summary
- add localized catalog rules endpoint to wizard assets and expose light styles for the summary area
- hydrate the modal rules region on open using documented query params with loading/error feedback
- extend assets test coverage for rules endpoint localization

## Testing
- composer phpcs *(fails: vendor/bin/phpcs not found in container)*
- composer phpstan *(fails: vendor/bin/phpstan not found in container)*
- composer test *(fails: vendor/bin/phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4f3d74d0832388a95e8cfbd3fb48