### PR TITLE
feat(p4): builder de payload desde DOM + guard de CTA (loading/aria-busy)

### DIFF
--- a/plugins/gafas3d-wizard-modal/assets/css/wizard-modal.css
+++ b/plugins/gafas3d-wizard-modal/assets/css/wizard-modal.css
@@ -48,8 +48,9 @@ body.g3d-wizard-open {
   min-height: 1.5em;
 }
 
+.g3d-wizard-modal__rules[aria-busy="true"],
 .g3d-wizard-modal__msg[aria-busy="true"] {
-  opacity: .8;
+  opacity: .7;
 }
 
 .g3d-wizard-modal__verify {


### PR DESCRIPTION
## Summary
- build the wizard payload from DOM state keys and gate the CTA/rules UI while loading or posting
- persist the last validate-sign payload/response for reuse by verify and clean busy messaging updates
- adjust busy-state opacity styling for rules/message containers

## Testing
- composer phpcs
- composer phpstan
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dc514f089c8323b1e3287e2824d4d3