### PR TITLE
chore(p3): smoke test de registro REST (validate-sign y verify) + wiring

### DIFF
--- a/plugins/g3d-validate-sign/tests/Routes/RouteRegistrationTest.php
+++ b/plugins/g3d-validate-sign/tests/Routes/RouteRegistrationTest.php
@@ -6,13 +6,15 @@ namespace G3D\ValidateSign\Tests\Routes;
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
+
 final class RouteRegistrationTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
-        if (!function_exists('sodium_crypto_sign_keypair')) {
+        if (!\function_exists('sodium_crypto_sign_keypair')) {
             self::markTestSkipped(
                 'ext-sodium requerida para las pruebas (ver docs/plugin-3-g3d-validate-sign.md §4.1).'
             );
@@ -28,27 +30,22 @@ final class RouteRegistrationTest extends TestCase
         $GLOBALS['g3d_tests_registered_rest_routes'] = [];
     }
 
-    public function testValidateSignRouteRegistered(): void
+    public function testValidateSignRouteIsRegistered(): void
     {
         \do_action('rest_api_init');
-
         self::assertTrue(self::routeExists('g3d/v1', '/validate-sign', 'POST'));
     }
 
-    public function testVerifyRouteRegistered(): void
+    public function testVerifyRouteIsRegistered(): void
     {
         \do_action('rest_api_init');
-
         self::assertTrue(self::routeExists('g3d/v1', '/verify', 'POST'));
     }
 
     private static function routeExists(string $ns, string $route, string $method): bool
     {
-        /**
-         * @var list<array{namespace:string,route:string,args:array<string,mixed>}> $routes
-         */
-        $routes = $GLOBALS['g3d_tests_registered_rest_routes'];
-
+        /** @var list<array{namespace:string,route:string,args:array<string,mixed>}> $routes */
+        $routes = $GLOBALS['g3d_tests_registered_rest_routes'] ?? [];
         foreach ($routes as $r) {
             if ($r['namespace'] === $ns && $r['route'] === $route) {
                 $methods = $r['args']['methods'] ?? '';

--- a/plugins/g3d-validate-sign/tests/Routes/RouteRegistrationTest.php
+++ b/plugins/g3d-validate-sign/tests/Routes/RouteRegistrationTest.php
@@ -6,13 +6,14 @@ namespace G3D\ValidateSign\Tests\Routes;
 
 use PHPUnit\Framework\TestCase;
 
-require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
-
 final class RouteRegistrationTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
+
+        // Cargar bootstrap de pruebas SIN efectos laterales a nivel de archivo
+        require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
 
         if (!\function_exists('sodium_crypto_sign_keypair')) {
             self::markTestSkipped(


### PR DESCRIPTION
## Summary
- add a smoke test that ensures the validate-sign and verify routes are registered during `rest_api_init`

## Testing
- vendor/bin/phpunit --configuration plugins/g3d-validate-sign/phpunit.xml.dist
- composer phpcs
- composer phpstan
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dc5a04805c83239d90e75c974f52fe