### PR TITLE
chore(p2): smoke test de registro REST (GET /catalog/rules) + wiring

### DIFF
--- a/plugins/g3d-catalog-rules/tests/Routes/RulesRouteRegistrationTest.php
+++ b/plugins/g3d-catalog-rules/tests/Routes/RulesRouteRegistrationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace {
     require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
+    require_once __DIR__ . '/../../plugin.php';
 }
 
 namespace G3D\CatalogRules\Tests\Routes {
@@ -17,43 +18,23 @@ namespace G3D\CatalogRules\Tests\Routes {
             parent::setUp();
 
             $GLOBALS['g3d_tests_registered_rest_routes'] = [];
-            $GLOBALS['g3d_tests_wp_actions']            = [];
-
-            require __DIR__ . '/../../plugin.php';
         }
 
-        public function testRegistersReadOnlyCatalogRulesRoute(): void
+        public function testRulesReadRouteIsRegistered(): void
         {
             \do_action('rest_api_init');
-
-            /**
-             * @var list<array{namespace:string,route:string,args:array<string,mixed>}> $routes
-             */
-            $routes = $GLOBALS['g3d_tests_registered_rest_routes'] ?? [];
-
-            self::assertTrue(
-                self::routeExists('g3d/v1', '/catalog/rules', 'GET', $routes),
-                'La ruta GET /g3d/v1/catalog/rules debe registrarse en rest_api_init.'
-            );
+            self::assertTrue(self::routeExists('g3d/v1', '/catalog/rules', 'GET'));
         }
 
-        /**
-         * @param list<array{namespace:string,route:string,args:array<string,mixed>}> $routes
-         */
-        private static function routeExists(
-            string $namespace,
-            string $route,
-            string $method,
-            array $routes
-        ): bool {
-            foreach ($routes as $definition) {
-                if ($definition['namespace'] !== $namespace || $definition['route'] !== $route) {
-                    continue;
+        private static function routeExists(string $ns, string $route, string $method): bool
+        {
+            /** @var list<array{namespace:string,route:string,args:array<string,mixed>}> $routes */
+            $routes = $GLOBALS['g3d_tests_registered_rest_routes'] ?? [];
+            foreach ($routes as $r) {
+                if ($r['namespace'] === $ns && $r['route'] === $route) {
+                    $m = $r['args']['methods'] ?? '';
+                    return \is_string($m) ? \str_contains($m, $method) : false;
                 }
-
-                $methods = $definition['args']['methods'] ?? '';
-
-                return \is_string($methods) && \str_contains($methods, $method);
             }
 
             return false;


### PR DESCRIPTION
## Summary
- add a smoke test that exercises the GET /g3d/v1/catalog/rules route registration via rest_api_init

## Testing
- composer phpcs
- composer phpstan
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dc5ee82c7c83239fe8c1c228aceb49