### PR TITLE
chore(p3): smoke test de registro REST (validate-sign / verify) + wiring

### DIFF
--- a/plugins/g3d-validate-sign/tests/Routes/RouteRegistrationTest.php
+++ b/plugins/g3d-validate-sign/tests/Routes/RouteRegistrationTest.php
@@ -6,27 +6,20 @@ namespace G3D\ValidateSign\Tests\Routes;
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
+require_once __DIR__ . '/../../plugin.php';
+
 final class RouteRegistrationTest extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        parent::setUpBeforeClass();
-
-        // Cargar bootstrap de pruebas SIN efectos laterales a nivel de archivo
-        require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
-
-        if (!\function_exists('sodium_crypto_sign_keypair')) {
-            self::markTestSkipped(
-                'ext-sodium requerida para las pruebas (ver docs/plugin-3-g3d-validate-sign.md §4.1).'
-            );
-        }
-
-        require_once __DIR__ . '/../../plugin.php';
-    }
-
     protected function setUp(): void
     {
         parent::setUp();
+
+        if (!\function_exists('sodium_crypto_sign_detached')) {
+            $this->markTestSkipped(
+                'ext-sodium requerida para las pruebas (ver docs/plugin-3-g3d-validate-sign.md §4.1).'
+            );
+        }
 
         $GLOBALS['g3d_tests_registered_rest_routes'] = [];
     }

--- a/plugins/g3d-validate-sign/tests/Routes/RouteRegistrationTest.php
+++ b/plugins/g3d-validate-sign/tests/Routes/RouteRegistrationTest.php
@@ -6,11 +6,17 @@ namespace G3D\ValidateSign\Tests\Routes;
 
 use PHPUnit\Framework\TestCase;
 
-require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
-require_once __DIR__ . '/../../plugin.php';
-
 final class RouteRegistrationTest extends TestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        // Carga bootstrap y plugin sin producir efectos a nivel de archivo.
+        require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
+        require_once __DIR__ . '/../../plugin.php';
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -40,6 +46,7 @@ final class RouteRegistrationTest extends TestCase
     {
         /** @var list<array{namespace:string,route:string,args:array<string,mixed>}> $routes */
         $routes = $GLOBALS['g3d_tests_registered_rest_routes'] ?? [];
+
         foreach ($routes as $r) {
             if ($r['namespace'] === $ns && $r['route'] === $route) {
                 $methods = $r['args']['methods'] ?? '';


### PR DESCRIPTION
## Summary
- añade pruebas de humo que verifican el registro de POST /g3d/v1/validate-sign y /verify
- reutiliza el bootstrap del helper y carga el plugin antes de disparar rest_api_init, saltando si falta ext-sodium

## Testing
- composer phpcs
- composer phpstan
- composer test
- vendor/bin/phpunit --configuration plugins/g3d-validate-sign/phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68dc60a27340832387776cf2c487ef7f