### PR TITLE
chore(p3): smoke test de registro REST (validate-sign/verify) + wiring

### DIFF
--- a/plugins/g3d-validate-sign/tests/Routes/RouteRegistrationTest.php
+++ b/plugins/g3d-validate-sign/tests/Routes/RouteRegistrationTest.php
@@ -6,11 +6,17 @@ namespace G3D\ValidateSign\Tests\Routes;
 
 use PHPUnit\Framework\TestCase;
 
-require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
-require_once __DIR__ . '/../../plugin.php';
-
 final class RouteRegistrationTest extends TestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        // Carga bootstrap y plugin sin efectos a nivel de archivo (evita side-effects en PSR-12).
+        require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
+        require_once __DIR__ . '/../../plugin.php';
+    }
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/plugins/g3d-validate-sign/tests/Routes/RouteRegistrationTest.php
+++ b/plugins/g3d-validate-sign/tests/Routes/RouteRegistrationTest.php
@@ -6,17 +6,11 @@ namespace G3D\ValidateSign\Tests\Routes;
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
+require_once __DIR__ . '/../../plugin.php';
+
 final class RouteRegistrationTest extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        parent::setUpBeforeClass();
-
-        // Carga bootstrap y plugin sin producir efectos a nivel de archivo.
-        require_once __DIR__ . '/../../../g3d-vendor-base-helper/tests/bootstrap.php';
-        require_once __DIR__ . '/../../plugin.php';
-    }
-
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
## Summary
- add smoke coverage to ensure the plugin registers the validate-sign and verify REST routes during rest_api_init
- rely on the shared vendor bootstrap and skip tests cleanly when ext-sodium is unavailable

## Testing
- composer phpcs
- composer phpstan
- composer test
- vendor/bin/phpunit --configuration plugins/g3d-validate-sign/phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68dc6a72d41c8323859143da65ecc2e4