### PR TITLE
feat(p4f): Wizard — TTL de caducidad + auto-verify opcional + estados de carga (JS plano) + tests

### DIFF
--- a/plugins/gafas3d-wizard-modal/assets/css/wizard-modal.css
+++ b/plugins/gafas3d-wizard-modal/assets/css/wizard-modal.css
@@ -68,8 +68,7 @@ body.g3d-wizard-open {
   margin-left: 0.75rem;
 }
 
-.g3d-wizard-modal__cta[disabled],
-.g3d-wizard-modal__verify[disabled] {
-  opacity: .5;
+.g3d-wizard-modal__footer button[disabled] {
+  opacity: .6;
   cursor: not-allowed;
 }


### PR DESCRIPTION
## Summary
- add a TTL countdown after validate-sign responses, including expiration handling and cleanup hooks
- add optional auto-verify triggering with explicit loading states for validate and verify buttons
- update modal teardown and button styles to restore states and reflect disabled controls consistently

## Testing
- composer phpcs
- composer phpstan
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dc8483057083238fe90b0fac591941