### PR TITLE
feat(p4j): estados accesibles (aria-busy + live announcements) y anti doble-submit en Wizard

### DIFF
--- a/plugins/gafas3d-wizard-modal/assets/css/wizard-modal.css
+++ b/plugins/gafas3d-wizard-modal/assets/css/wizard-modal.css
@@ -6,6 +6,10 @@ body.g3d-wizard-open {
   overflow: hidden;
 }
 
+.g3d-wizard--busy {
+  cursor: progress;
+}
+
 .g3d-wizard-modal__overlay {
   position: fixed;
   inset: 0;
@@ -29,7 +33,7 @@ body.g3d-wizard-open {
   padding: 1.5rem;
 }
 
-.g3d-wizard-modal.is-busy {
+.g3d-wizard-modal.g3d-wizard--busy {
   opacity: 0.85;
 }
 


### PR DESCRIPTION
## Summary
- add accessible busy helper, inflight guards and live announcements to wizard modal flows
- prevent double submissions for validate and verify actions while keeping announcements in the existing live region
- expose a shared busy cursor and maintain message spacing in CSS for consistent feedback

## Testing
- composer phpcs
- composer phpstan
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dc9b515d2483238608a4e177178bd8