### PR TITLE
feat(p4l): estados busy + aria-live en validate/verify y cancelación al cerrar

### DIFF
--- a/plugins/gafas3d-wizard-modal/assets/css/wizard-modal.css
+++ b/plugins/gafas3d-wizard-modal/assets/css/wizard-modal.css
@@ -6,10 +6,6 @@ body.g3d-wizard-open {
   overflow: hidden;
 }
 
-.g3d-wizard--busy {
-  cursor: progress;
-}
-
 .g3d-wizard-modal__overlay {
   position: fixed;
   inset: 0;
@@ -33,8 +29,9 @@ body.g3d-wizard-open {
   padding: 1.5rem;
 }
 
-.g3d-wizard-modal.g3d-wizard--busy {
-  opacity: 0.85;
+.g3d-wizard-modal[aria-busy="true"] {
+  opacity: 0.75;
+  pointer-events: none;
 }
 
 [role="tab"]:focus {
@@ -57,7 +54,7 @@ body.g3d-wizard-open {
 
 .g3d-wizard-modal__msg {
   margin-top: 0.75rem;
-  font-size: .9rem;
+  font-size: 0.95rem;
   min-height: 1.5em;
 }
 


### PR DESCRIPTION
## Summary
- add session AbortController handling, busy helpers, and aria-live messaging updates to the validate/sign and verify flows
- reset network state on modal open/close while clearing busy indicators and reusing the new button helper
- soften the modal styling when aria-busy is active and adjust the live-region typography

## Testing
- composer phpcs
- composer phpstan
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dca02bc2148323b86f839b60f15cec