### PR TITLE
feat(p4f): propagate shortcode attrs to wizard modal

### DIFF
--- a/plugins/gafas3d-wizard-modal/src/Shortcode/WizardShortcode.php
+++ b/plugins/gafas3d-wizard-modal/src/Shortcode/WizardShortcode.php
@@ -7,10 +7,16 @@ namespace Gafas3d\WizardModal\Shortcode;
 use Gafas3d\WizardModal\UI\Modal;
 
 use function add_shortcode;
+use function array_change_key_case;
 use function esc_attr;
+use function get_locale;
 use function implode;
 use function ob_get_clean;
 use function ob_start;
+use function preg_quote;
+use function preg_replace;
+use function sanitize_text_field;
+use function shortcode_atts;
 use function sprintf;
 use function str_contains;
 
@@ -25,10 +31,25 @@ final class WizardShortcode
 
     public static function register(): void
     {
-        add_shortcode(self::SHORTCODE_TAG, static function (): string {
+        add_shortcode(self::SHORTCODE_TAG, static function (array $attrs = []): string {
+            $defaults = [
+                'producto_id' => '',
+                'snapshot_id' => '',
+                'locale' => get_locale(),
+            ];
+
+            $normalizedAttrs = array_change_key_case($attrs, CASE_LOWER);
+            $parsedAttrs = shortcode_atts($defaults, $normalizedAttrs, self::SHORTCODE_TAG);
+
+            $productoId = sanitize_text_field((string) $parsedAttrs['producto_id']);
+            $snapshotId = sanitize_text_field((string) $parsedAttrs['snapshot_id']);
+            $locale = sanitize_text_field((string) $parsedAttrs['locale']);
+
             ob_start();
             Modal::render();
             $modalHtml = (string) ob_get_clean();
+
+            $modalHtml = self::injectDataAttributes($modalHtml, $productoId, $snapshotId, $locale);
 
             if (str_contains($modalHtml, 'id="' . self::ROOT_ID . '"')) {
                 return $modalHtml;
@@ -56,5 +77,31 @@ final class WizardShortcode
                 $modalHtml
             );
         });
+    }
+
+    private static function injectDataAttributes(
+        string $html,
+        string $productoId,
+        string $snapshotId,
+        string $locale
+    ): string {
+        $htmlWithProducto = self::replaceAttribute($html, 'data-producto-id', $productoId);
+        $htmlWithSnapshot = self::replaceAttribute($htmlWithProducto, 'data-snapshot-id', $snapshotId);
+
+        return self::replaceAttribute($htmlWithSnapshot, 'data-locale', $locale);
+    }
+
+    private static function replaceAttribute(string $html, string $attribute, string $value): string
+    {
+        $pattern = sprintf('/%s="[^"]*"/', preg_quote($attribute, '/'));
+        $replacement = sprintf('%s="%s"', $attribute, esc_attr($value));
+
+        $replaced = preg_replace($pattern, $replacement, $html, 1);
+
+        if ($replaced === null) {
+            return $html;
+        }
+
+        return $replaced;
     }
 }

--- a/plugins/gafas3d-wizard-modal/tests/Shortcode/WizardShortcodeRenderTest.php
+++ b/plugins/gafas3d-wizard-modal/tests/Shortcode/WizardShortcodeRenderTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gafas3d\WizardModal\Tests\Shortcode;
+
+use Gafas3d\WizardModal\Shortcode\WizardShortcode;
+use PHPUnit\Framework\TestCase;
+
+use function get_locale;
+
+final class WizardShortcodeRenderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['g3d_wizard_modal_shortcodes'] = [];
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        WizardShortcode::register();
+
+        self::assertArrayHasKey('g3d_wizard_modal', $GLOBALS['g3d_wizard_modal_shortcodes']);
+
+        $callback = $GLOBALS['g3d_wizard_modal_shortcodes']['g3d_wizard_modal'];
+        $html = $callback([
+            'producto_id' => 'prod:rx',
+            'snapshot_id' => 'snap:2025-10-01',
+            'locale' => 'es_ES',
+        ]);
+
+        self::assertStringContainsString('data-producto-id="prod:rx"', $html);
+        self::assertStringContainsString('data-snapshot-id="snap:2025-10-01"', $html);
+        self::assertStringContainsString('data-locale="es_ES"', $html);
+    }
+
+    public function testRenderWithoutAttributesUsesDefaults(): void
+    {
+        WizardShortcode::register();
+
+        self::assertArrayHasKey('g3d_wizard_modal', $GLOBALS['g3d_wizard_modal_shortcodes']);
+
+        $callback = $GLOBALS['g3d_wizard_modal_shortcodes']['g3d_wizard_modal'];
+        $html = $callback([]);
+
+        self::assertStringContainsString('data-producto-id=""', $html);
+        self::assertStringContainsString('data-snapshot-id=""', $html);
+        self::assertStringContainsString('data-locale="' . get_locale() . '"', $html);
+    }
+}

--- a/plugins/gafas3d-wizard-modal/tests/bootstrap.php
+++ b/plugins/gafas3d-wizard-modal/tests/bootstrap.php
@@ -103,6 +103,67 @@ if (!function_exists('get_locale')) {
     }
 }
 
+if (!isset($GLOBALS['g3d_wizard_modal_shortcodes'])) {
+    /**
+     * @var array<string, callable> $GLOBALS['g3d_wizard_modal_shortcodes']
+     */
+    $GLOBALS['g3d_wizard_modal_shortcodes'] = [];
+}
+
+if (!function_exists('add_shortcode')) {
+    /**
+     * @param callable $callback
+     */
+    function add_shortcode(string $tag, callable $callback): void
+    {
+        $GLOBALS['g3d_wizard_modal_shortcodes'][$tag] = $callback;
+    }
+}
+
+if (!function_exists('shortcode_atts')) {
+    /**
+     * @param array<string, mixed> $pairs
+     * @param array<string, mixed> $atts
+     * @return array<string, mixed>
+     */
+    function shortcode_atts(array $pairs, array $atts, string $shortcode = ''): array
+    {
+        unset($shortcode);
+
+        $out = [];
+
+        foreach ($pairs as $name => $default) {
+            if (array_key_exists($name, $atts)) {
+                $out[$name] = $atts[$name];
+            } else {
+                $out[$name] = $default;
+            }
+        }
+
+        foreach ($atts as $name => $value) {
+            if (!array_key_exists($name, $out)) {
+                $out[$name] = $value;
+            }
+        }
+
+        return $out;
+    }
+}
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field(string $text): string
+    {
+        $text = strip_tags($text);
+        $text = preg_replace('/[\r\n\t]+/', ' ', $text);
+
+        if ($text === null) {
+            $text = '';
+        }
+
+        return trim($text);
+    }
+}
+
 if (!isset($GLOBALS['g3d_wizard_modal_enqueued_scripts'])) {
     /**
      * @var array<string, array{src:string,deps:array<int, string>,ver:string|bool,in_footer:bool}> $GLOBALS['g3d_wizard_modal_enqueued_scripts']


### PR DESCRIPTION
## Summary
- accept producto_id, snapshot_id, and locale attributes in the g3d_wizard_modal shortcode and inject them into the modal data attributes
- extend the test bootstrap with shortcode helpers and cover the shortcode rendering behaviour
- ensure the modal markup tests continue to assert for the data attribute presence

## Testing
- vendor/bin/phpunit --configuration plugins/gafas3d-wizard-modal/phpunit.xml.dist
- vendor/bin/phpstan analyse --configuration=phpstan.neon.dist --memory-limit=512M

------
https://chatgpt.com/codex/tasks/task_e_68dcae9157888323b560f3eb11ff594b