### PR TITLE
feat: wire wizard rules fetch with minimal gating

### DIFF
--- a/plugins/gafas3d-wizard-modal/assets/js/wizard-modal.js
+++ b/plugins/gafas3d-wizard-modal/assets/js/wizard-modal.js
@@ -10,17 +10,9 @@
 
   global.G3DWIZARD = global.G3DWIZARD || {};
 
-  global.G3DWIZARD.getJson = async function getJson(url, params) {
-    const qs = params && Object.keys(params).length
-      ? '?' + new URLSearchParams(params).toString()
-      : '';
-    const res = await fetch(url + qs, {
-      method: 'GET',
-      headers: {
-        'X-WP-Nonce': (global.G3DWIZARD && global.G3DWIZARD.nonce) || ''
-      }
-    });
-
+  global.G3DWIZARD.getJson = async function getJson(url, query) {
+    const qs = query ? '?' + new URLSearchParams(query).toString() : '';
+    const res = await fetch(url + qs, { method: 'GET' });
     return res;
   };
 
@@ -805,7 +797,11 @@
       var payload = data && typeof data === 'object' ? data : {};
       var rulesList = Array.isArray(payload.rules) ? payload.rules : [];
 
-      return 'Reglas cargadas: ' + String(rulesList.length);
+      return (
+        'Reglas cargadas (' +
+        String(rulesList.length) +
+        ') — TODO(plugin-4-gafas3d-wizard-modal.md §5.6).'
+      );
     }
 
     function formatRulesError(response, payload) {
@@ -1308,6 +1304,7 @@
       rulesPromise = getJSON(endpoint, params);
 
       setRulesBusyState(true);
+      setRulesSummaryMessage(__('Cargando…', TEXT_DOMAIN));
 
       try {
         var result = await rulesPromise;

--- a/plugins/gafas3d-wizard-modal/src/Assets/Assets.php
+++ b/plugins/gafas3d-wizard-modal/src/Assets/Assets.php
@@ -67,6 +67,7 @@ final class Assets
                 'api' => [
                     'validateSign' => rest_url('g3d/v1/validate-sign'),
                     'verify' => rest_url('g3d/v1/verify'),
+                    // TODO(plugin-2-g3d-catalog-rules.md §6): confirmar ruta pública.
                     'rules' => rest_url('g3d/v1/catalog/rules'),
                 ],
                 'nonce' => wp_create_nonce('wp_rest'),


### PR DESCRIPTION
## Summary
- use a plain GET helper for wizard requests and keep the catalog rules payload stored untouched
- surface a loading notice and TODO-based rules summary so the CTA remains available when docs lack explicit gating
- document the catalog rules endpoint as a TODO in the localized asset data

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dcb42bcad88323aab82656b31a117c