### PR TITLE
feat: fetch wizard rules with params

### DIFF
--- a/plugins/gafas3d-wizard-modal/tests/UI/ModalRenderTest.php
+++ b/plugins/gafas3d-wizard-modal/tests/UI/ModalRenderTest.php
@@ -76,6 +76,37 @@ final class ModalRenderTest extends TestCase
         self::assertInstanceOf(\DOMElement::class, $listNode);
     }
 
+    public function testModalContainerPreservesSnapshotProductoAndLocale(): void
+    {
+        ob_start();
+        Modal::render();
+        $output = (string) ob_get_clean();
+
+        $previous = libxml_use_internal_errors(true);
+        $document = new \DOMDocument();
+        $document->loadHTML('<?xml encoding="utf-8" ?>' . $output);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        $xpath = new \DOMXPath($document);
+
+        $overlay = $xpath->query('//*[@data-g3d-wizard-modal-overlay]')->item(0);
+
+        self::assertInstanceOf(\DOMElement::class, $overlay);
+
+        $modalNode = $xpath
+            ->query('.//*[@class="g3d-wizard-modal" or contains(@class,"g3d-wizard-modal ")]', $overlay)
+            ->item(0);
+
+        self::assertInstanceOf(\DOMElement::class, $modalNode);
+        self::assertTrue($modalNode->hasAttribute('data-snapshot-id'));
+        self::assertTrue($modalNode->hasAttribute('data-producto-id'));
+        self::assertTrue($modalNode->hasAttribute('data-locale'));
+        self::assertSame('', $modalNode->getAttribute('data-snapshot-id'));
+        self::assertSame('', $modalNode->getAttribute('data-producto-id'));
+        self::assertSame(get_locale(), $modalNode->getAttribute('data-locale'));
+    }
+
     public function testRenderContainsSinglePoliteMessageRegion(): void
     {
         ob_start();


### PR DESCRIPTION
## Summary
- add a helper to call the catalog rules endpoint with documented snapshot/producto/locale parameters and reuse cached results inside the modal
- render accessible loading, empty, success, and error states for the rules summary and list without changing the contract
- extend the modal render test suite to ensure the data attributes for snapshot/producto/locale stay on the container

## Testing
- composer phpcs
- composer phpstan
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dcbc8f71a08323b26bd7b08d41a425