### PR TITLE
feat(p2): validate rules endpoint params

### DIFF
--- a/plugins/g3d-catalog-rules/tests/Api/RulesReadParamsTest.php
+++ b/plugins/g3d-catalog-rules/tests/Api/RulesReadParamsTest.php
@@ -14,14 +14,18 @@ namespace G3D\CatalogRules\Tests\Api {
     use WP_REST_Request;
     use WP_REST_Response;
 
-    final class RulesReadRouteTest extends TestCase
+    /**
+     * @covers \G3D\CatalogRules\Api\RulesReadController::handle
+     */
+    final class RulesReadParamsTest extends TestCase
     {
-        public function testSuccessfulResponseReturnsStubbedSnapshot(): void
+        public function testHandleSucceedsWithValidParams(): void
         {
             $controller = new RulesReadController();
             $request    = new WP_REST_Request('GET', '/g3d/v1/catalog/rules');
-            $request->set_param('producto_id', 'prod:base');
-            $request->set_param('locale', 'es-ES');
+            $request->set_param('producto_id', 'prod:rx-classic');
+            $request->set_param('snapshot_id', 'snap:2025-09-01');
+            $request->set_param('locale', 'es_ES');
 
             $response = $controller->handle($request);
 
@@ -32,37 +36,43 @@ namespace G3D\CatalogRules\Tests\Api {
             self::assertIsArray($data);
             self::assertArrayHasKey('rules', $data);
             self::assertIsArray($data['rules']);
+            self::assertSame('snap:2025-09-27T18:45:00Z', $data['id']);
         }
 
-        public function testMissingRequiredParamsReturnsWpError(): void
+        public function testHandleReturnsErrorWhenProductoIdMissing(): void
         {
             $controller = new RulesReadController();
             $request    = new WP_REST_Request('GET', '/g3d/v1/catalog/rules');
+            $request->set_param('snapshot_id', 'snap:2025-09-01');
+            $request->set_param('locale', 'es_ES');
 
             $response = $controller->handle($request);
 
             self::assertInstanceOf(WP_Error::class, $response);
             self::assertSame('rest_missing_required_params', $response->get_error_code());
+
             $errorData = $response->get_error_data();
             self::assertIsArray($errorData);
             self::assertSame(400, $errorData['status']);
             self::assertContains('producto_id', $errorData['missing_fields']);
         }
 
-        public function testInvalidParamTypeReturnsWpError(): void
+        public function testHandleReturnsErrorWhenSnapshotIdHasInvalidType(): void
         {
             $controller = new RulesReadController();
             $request    = new WP_REST_Request('GET', '/g3d/v1/catalog/rules');
-            $request->set_param('producto_id', 123);
+            $request->set_param('producto_id', 'prod:rx-classic');
+            $request->set_param('snapshot_id', ['snap:2025-09-01']);
 
             $response = $controller->handle($request);
 
             self::assertInstanceOf(WP_Error::class, $response);
             self::assertSame('rest_invalid_param', $response->get_error_code());
+
             $errorData = $response->get_error_data();
             self::assertIsArray($errorData);
             self::assertSame(400, $errorData['status']);
-            self::assertContains('producto_id', $errorData['type_errors']);
+            self::assertContains('snapshot_id', $errorData['type_errors']);
         }
     }
 }


### PR DESCRIPTION
## Summary
- validate producto_id, snapshot_id and locale query parameters in the catalog rules endpoint, returning WordPress-standard errors when validation fails
- keep the snapshot stub response and add TODOs for future locale/snapshot filtering as indicated in the docs
- add coverage for valid and invalid parameter scenarios, updating existing route tests accordingly

## Testing
- composer test
- composer phpstan
- composer phpcs

------
https://chatgpt.com/codex/tasks/task_e_68dcbf5997348323accc6614601b43ae